### PR TITLE
docs: add learnings from rte_ckeditor_image PR #495 session

### DIFF
--- a/skills/typo3-ddev/SKILL.md
+++ b/skills/typo3-ddev/SKILL.md
@@ -155,6 +155,57 @@ $GLOBALS["TYPO3_CONF_VARS"]["SYS"]["features"]["security.backend.enforceReferrer
 
 This prevents "Invalid Referrer" and "Trusted Host" errors in the multi-subdomain DDEV environment.
 
+## Security Best Practices
+
+### MySQL Credential Handling
+
+**Always use `MYSQL_PWD` environment variable** instead of `-p"$PASSWORD"` to avoid exposing passwords in process lists:
+
+```bash
+# Bad: Password visible in `ps aux` output
+mysql -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASSWORD" -e "DROP DATABASE IF EXISTS v13"
+
+# Good: Password hidden via environment variable
+export MYSQL_PWD="${MYSQL_PASSWORD:-root}"
+mysql -h "$DB_HOST" -u "$DB_USER" -e "DROP DATABASE IF EXISTS v13"
+```
+
+**Why:**
+- Command-line arguments are visible to all users via `ps aux`
+- `MYSQL_PWD` is read by MySQL client but not exposed in process list
+- Use defaults for DDEV environment: `${MYSQL_PASSWORD:-root}`
+
+### Safe YAML Manipulation
+
+**Use PHP `yaml_parse()`/`yaml_emit()` instead of fragile `sed` commands** for modifying YAML config files:
+
+```bash
+# Bad: Fragile sed-based YAML editing
+sed -i '/^dependencies:/d' config/sites/main/config.yaml
+sed -i '/^  - /d' config/sites/main/config.yaml
+echo "dependencies:" >> config/sites/main/config.yaml
+echo "  - bootstrap-package/full" >> config/sites/main/config.yaml
+
+# Good: Safe PHP-based YAML manipulation
+php -r "
+    \$file = 'config/sites/main/config.yaml';
+    \$yaml = yaml_parse_file(\$file);
+    \$yaml['dependencies'] = ['bootstrap-package/full'];
+    file_put_contents(\$file, yaml_emit(\$yaml, YAML_UTF8_ENCODING));
+" 2>/dev/null || {
+    # Fallback: append if PHP yaml extension not available
+    if ! grep -q '^dependencies:' config/sites/main/config.yaml; then
+        echo "dependencies:" >> config/sites/main/config.yaml
+        echo "  - bootstrap-package/full" >> config/sites/main/config.yaml
+    fi
+}
+```
+
+**Why:**
+- `sed` can break YAML structure (indentation, multiline values)
+- PHP yaml functions properly parse and emit valid YAML
+- Fallback ensures compatibility when yaml extension unavailable
+
 ## Troubleshooting
 
 | Issue | Solution |

--- a/skills/typo3-docs/SKILL.md
+++ b/skills/typo3-docs/SKILL.md
@@ -143,7 +143,49 @@ Always use card-grid instead of plain toctree lists:
 
 For guides.xml structure and migration, see: `references/typo3-directives.md`
 
-**4. literalinclude for Code Examples**
+**4. Version Configuration (Dev vs Release)**
+
+Version settings differ between development branches and tagged releases:
+
+```xml
+<!-- For main/dev branch (dynamic): -->
+<project title="Extension Name"
+         version="main"
+         release="main"/>
+<extension typo3-core-preferred="stable"/>
+
+<!-- For tagged release (specific): -->
+<project title="Extension Name"
+         version="13.1"
+         release="13.1.5"/>
+<extension typo3-core-preferred="13.4"/>
+```
+
+**Settings.cfg equivalent:**
+```ini
+# For main/dev branch:
+version = main
+release = main
+
+# For tagged release:
+version = 13.1
+release = 13.1.5
+```
+
+**Interlink URLs:**
+```xml
+<!-- Dev branch: use /main/en-us/ -->
+<inventory id="t3coreapi"
+           url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+
+<!-- Tagged release: use specific version -->
+<inventory id="t3coreapi"
+           url="https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/"/>
+```
+
+**Rule:** Release documentation should point to the versions it was designed for and tested with. Only dev branches use dynamic `main`/`stable` references.
+
+**5. literalinclude for Code Examples**
 
 Prefer `literalinclude` over inline code blocks for scripts longer than 20 lines:
 

--- a/skills/typo3-extension-upgrade/SKILL.md
+++ b/skills/typo3-extension-upgrade/SKILL.md
@@ -285,6 +285,55 @@ $rectorConfig->sets([
 
 **Rule**: Always use v12-compatible APIs when supporting both versions.
 
+### TYPO3 v13 + v14 Dual Compatibility
+
+When supporting both v13.4 LTS and v14.0+, use runtime feature detection instead of try-catch:
+
+**Pattern: method_exists for Runtime Detection**
+
+```php
+// Good: Clear runtime detection
+if (method_exists(GridColumnItem::class, 'getRow')) {
+    // TYPO3 v14+ path - getRow() was added in v14
+    $record = $item->getRow();
+} else {
+    // TYPO3 v13 path - use legacy method
+    $record = $item->getRecord();
+}
+```
+
+```php
+// Bad: Try-catch masks real errors
+try {
+    $record = $item->getRow();
+} catch (Error $e) {
+    // Catches ALL errors, not just missing method
+    $record = $item->getRecord();
+}
+```
+
+**PHPStan Configuration for Dual Compatibility**
+
+```neon
+parameters:
+    ignoreErrors:
+        # v13/v14: method_exists check is always true/false depending on installed version
+        - identifier: function.alreadyNarrowedType
+          path: %currentWorkingDirectory%/Classes/Backend/MyClass.php
+          message: '#method_exists.*getRow#'
+          reportUnmatched: false
+        # v13/v14: method only exists in v14+
+        - identifier: method.notFound
+          path: %currentWorkingDirectory%/Classes/Backend/MyClass.php
+          message: '#getRow#'
+          reportUnmatched: false
+```
+
+**Key points:**
+- `reportUnmatched: false` - Prevents errors when pattern doesn't match (version-conditional)
+- Specific `path` and `message` patterns - Keep production code strict
+- `method_exists()` - Clear intent, self-documenting, no side effects
+
 ---
 
 ## Part 3: Common Issues & Solutions

--- a/skills/typo3-testing/references/ci-cd.md
+++ b/skills/typo3-testing/references/ci-cd.md
@@ -371,6 +371,71 @@ functional:sqlite:
 
 ## Best Practices
 
+### 0. CGL on Minimum PHP Version
+
+**Always run Code Guidelines (CGL/php-cs-fixer) on the extension's minimum supported PHP version**, not the maximum:
+
+```yaml
+# Good: CGL on minimum PHP from composer.json constraint
+- php: '8.2'  # Extension requires "php": "^8.2"
+  run_cgl: true
+
+# Bad: CGL on maximum PHP version
+- php: '8.5'
+  run_cgl: true  # Won't catch syntax incompatibility!
+```
+
+**Why minimum PHP is better:**
+- If someone accidentally uses PHP 8.5-only syntax, CGL will **fail with a parse error** on PHP 8.2
+- Running on max version would **hide** the issue - it would parse newer syntax that breaks on older versions
+- Since `"php": "^8.2"` means all code must be parseable on PHP 8.2+, running CGL there catches issues early
+- The test suite runs on ALL PHP versions anyway for full coverage
+
+**Important:** The minimum PHP version comes from your extension's `composer.json`, which may differ from TYPO3's minimum.
+
+### 0b. E2E Test Optimization
+
+**Run E2E tests once per CI run, not per matrix combination:**
+
+```yaml
+# E2E tests run once - browser behavior is PHP version independent
+- name: Run E2E Tests
+  run: Build/Scripts/runTests.sh -s e2e -p 8.5
+```
+
+**Why:**
+- E2E tests verify browser behavior (CKEditor integration, UI interactions)
+- Browser JavaScript execution is independent of backend PHP version
+- Running once saves significant CI time without losing coverage
+- Unit/functional tests already cover PHP version compatibility
+
+### 0c. PHPStan without phpstan-typo3
+
+When not using `saschaegerer/phpstan-typo3` (e.g., for TYPO3 v13/v14 dual compatibility), `GeneralUtility::makeInstance()` returns `mixed`. Use scoped ignore rules:
+
+```neon
+parameters:
+    ignoreErrors:
+        # Ignore makeInstance() mixed return type in functional tests
+        - identifier: argument.type
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          message: '#mixed#'
+          reportUnmatched: false
+        - identifier: assign.propertyType
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          message: '#mixed#'
+          reportUnmatched: false
+        - identifier: method.nonObject
+          path: %currentWorkingDirectory%/Tests/Functional/*
+          message: '#mixed#'
+          reportUnmatched: false
+```
+
+**Key patterns:**
+- `message: '#mixed#'` - Only matches errors containing "mixed" (scoped, not blanket)
+- `reportUnmatched: false` - Prevents errors when pattern doesn't match (version-conditional)
+- Keep production code (`Classes/`) strict with no such ignores
+
 ### 1. Fast Feedback Loop
 
 Order jobs by execution time (fastest first):


### PR DESCRIPTION
## Summary

Adds learnings from the rte_ckeditor_image TYPO3 v14 + PHP 8.5 support PR (#495) to relevant skills.

### typo3-testing (references/ci-cd.md)
- CGL should run on minimum PHP version (from extension's composer.json), not max - catches syntax incompatibility early
- E2E tests run once per CI (browser behavior is PHP-independent)
- PHPStan scoped ignore rules for `makeInstance()` mixed return type when not using phpstan-typo3

### typo3-ddev (SKILL.md)
- Use `MYSQL_PWD` env var instead of `-p"$PASSWORD"` for security (avoids password in process list)
- Use PHP `yaml_parse()`/`yaml_emit()` instead of fragile sed for YAML manipulation

### typo3-docs (SKILL.md)
- Version config differs for dev branches vs tagged releases
- Dev: `version=main`, `release=main`, `typo3-core-preferred=stable`
- Release: `version=X.Y`, `release=X.Y.Z`, `typo3-core-preferred=13.4`

### typo3-extension-upgrade (SKILL.md)
- TYPO3 v13/v14 dual compatibility patterns
- Use `method_exists()` for runtime detection instead of try-catch
- PHPStan `reportUnmatched=false` for version-conditional patterns

## Test plan
- [ ] Verify skill files render correctly
- [ ] Check code examples are syntactically valid