### PR TITLE
feat: add context7 skill to marketplace

### DIFF
--- a/.sync-config.json
+++ b/.sync-config.json
@@ -109,6 +109,12 @@
       "marketplace_name": "jira-integration"
     },
     {
+      "name": "context7",
+      "repository": "https://github.com/netresearch/context7-skill.git",
+      "target_path": "skills/context7",
+      "marketplace_name": "context7"
+    },
+    {
       "name": "coach",
       "repository": "https://github.com/netresearch/claude-coach-plugin.git",
       "target_path": "plugins/coach",


### PR DESCRIPTION
## Summary
- Adds Context7 documentation lookup skill as a lightweight alternative to Context7 MCP server
- Uses REST API directly with no persistent context overhead

## New Skill
- **Name**: context7
- **Repository**: https://github.com/netresearch/context7-skill
- **Purpose**: Fetch up-to-date library documentation without MCP context cost

## Features
- Search for library IDs
- Fetch documentation by topic
- Support for code and info modes
- No MCP tool schemas consuming context

## Why This Skill?
For users who occasionally need library docs but don't want the ~500-2000 token overhead of having MCP tool schemas always in context.