### PR TITLE
feat: add context7-skill to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -251,6 +251,20 @@
       "version": "3.1.2-20251225"
     },
     {
+      "name": "context7",
+      "description": "Fetch up-to-date library documentation via Context7 REST API. Lightweight alternative to Context7 MCP with no persistent context overhead. Covers 50+ libraries including React, Next.js, Vue, Express, Prisma, and more.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Netresearch DTT GmbH",
+        "email": "info@netresearch.de"
+      },
+      "source": {
+        "source": "github",
+        "repo": "netresearch/context7-skill"
+      },
+      "category": "development"
+    },
+    {
       "name": "coach",
       "description": "Self-improving learning system that detects friction signals (corrections, tool failures, repetition) and proposes rule updates. Includes /coach slash commands for reviewing, approving, and managing learning candidates. Auto-configures hooks for signal detection.",
       "version": "2.1.0",
@@ -287,7 +301,8 @@
         "./skills/git-workflow",
         "./skills/skill-repo",
         "./skills/github-project",
-        "./skills/jira-integration"
+        "./skills/jira-integration",
+        "./skills/context7"
       ]
     }
   ]

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -396,6 +396,26 @@ jobs:
           echo "JIRA_INTEGRATION_VERSION=$VERSION" >> $GITHUB_ENV
           echo "✓ jira-integration synced (version: $VERSION)"
 
+      - name: Sync context7 skill
+        run: |
+          echo "=== Syncing context7-skill ==="
+          git clone https://github.com/netresearch/context7-skill.git .sync-temp/context7
+          cd .sync-temp/context7
+          COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y%m%d)
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+' | head -1)
+          SEMVER=$(echo "$LATEST_TAG" | sed 's/^v//')
+          if [ -z "$SEMVER" ]; then SEMVER="1.0.0"; fi
+          VERSION="${SEMVER}-${COMMIT_DATE}"
+          cd ../..
+          rm -rf .sync-temp/context7/.git
+          mkdir -p skills/context7
+          rm -rf skills/context7/*
+          rm -rf skills/context7/.[!.]*
+          cp -r .sync-temp/context7/* skills/context7/
+          cp -r .sync-temp/context7/.claude-plugin skills/context7/ 2>/dev/null || true
+          echo "CONTEXT7_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "✓ context7 synced (version: $VERSION)"
+
       - name: Update marketplace.json versions
         run: |
           echo "=== Updating marketplace.json with latest versions ==="
@@ -418,6 +438,7 @@ jobs:
              --arg v16 "$SKILL_REPO_VERSION" \
              --arg v17 "$GITHUB_PROJECT_VERSION" \
              --arg v18 "$JIRA_INTEGRATION_VERSION" \
+             --arg v19 "$CONTEXT7_VERSION" \
              '(.plugins[] | select(.name == "enterprise-readiness") | .version) = $v1 |
               (.plugins[] | select(.name == "typo3-docs") | .version) = $v2 |
               (.plugins[] | select(.name == "typo3-testing") | .version) = $v3 |
@@ -435,12 +456,13 @@ jobs:
               (.plugins[] | select(.name == "git-workflow") | .version) = $v15 |
               (.plugins[] | select(.name == "skill-repo") | .version) = $v16 |
               (.plugins[] | select(.name == "github-project") | .version) = $v17 |
-              (.plugins[] | select(.name == "jira-integration") | .version) = $v18' \
+              (.plugins[] | select(.name == "jira-integration") | .version) = $v18 |
+              (.plugins[] | select(.name == "context7") | .version) = $v19' \
              .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
 
           mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
 
-          echo "✓ marketplace.json updated with all 18 skill versions"
+          echo "✓ marketplace.json updated with all 19 skill versions"
 
       - name: Cleanup temporary directories
         run: |
@@ -463,7 +485,7 @@ jobs:
       - name: Commit and push changes
         if: steps.changes.outputs.has_changes == 'true' || github.event.inputs.force_sync == 'true'
         run: |
-          git commit -m "chore: sync all 18 skills from source repositories
+          git commit -m "chore: sync all 19 skills from source repositories
 
           Synced versions:
           - enterprise-readiness: $ENTERPRISE_READINESS_VERSION
@@ -484,6 +506,7 @@ jobs:
           - skill-repo: $SKILL_REPO_VERSION
           - github-project: $GITHUB_PROJECT_VERSION
           - jira-integration: $JIRA_INTEGRATION_VERSION
+          - context7: $CONTEXT7_VERSION
 
           Triggered by: ${{ github.event_name }}"
 
@@ -493,11 +516,11 @@ jobs:
       - name: Summary
         run: |
           echo "=== Skill Sync Complete ==="
-          echo "✓ All 18 skills synchronized successfully"
+          echo "✓ All 19 skills synchronized successfully"
           echo ""
           echo "Skills synced:"
           echo "  - enterprise-readiness, typo3-docs, typo3-testing, typo3-ddev"
           echo "  - typo3-core-contributions, typo3-conformance, typo3-extension-upgrade"
           echo "  - netresearch-branding, agents, cli-tools"
           echo "  - go-development, php-modernization, security-audit, typo3-ckeditor5"
-          echo "  - git-workflow, skill-repo, github-project, jira-integration"
+          echo "  - git-workflow, skill-repo, github-project, jira-integration, context7"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Then use `/plugin` to browse and install plugins.
 | Netresearch Branding | [netresearch-branding-skill](https://github.com/netresearch/netresearch-branding-skill) | Apply Netresearch brand guidelines |
 | AGENTS.md Generator | [agents-skill](https://github.com/netresearch/agents-skill) | Generate AGENTS.md documentation |
 | CLI Tools | [cli-tools-skill](https://github.com/netresearch/cli-tools-skill) | Auto-install missing CLI tools |
+| Context7 | [context7-skill](https://github.com/netresearch/context7-skill) | Library documentation lookup via Context7 REST API |
 | Coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with friction detection |
 | Skill Repo | [skill-repo-skill](https://github.com/netresearch/skill-repo-skill) | Guide for structuring Netresearch skill repositories |
 
@@ -201,6 +202,19 @@ Automatic CLI tool management for coding agents with reactive and proactive mode
 - Smart installation method selection (GitHub releases, cargo, npm, apt/brew)
 - Support for Python, Node.js, Rust, Go, PHP, Ruby, and infrastructure projects
 - User-level installation priority (~/.local/bin, ~/.cargo/bin)
+
+### Context7
+Fetch up-to-date library documentation via Context7 REST API. Lightweight alternative to Context7 MCP with no persistent context overhead.
+
+**Repository:** https://github.com/netresearch/context7-skill
+
+**Features:**
+- No MCP overhead - uses REST API directly without consuming context through tool schemas
+- Current documentation access from Context7's curated database
+- Topic filtering for specific areas (hooks, routing, middleware, etc.)
+- Multi-library support covering 50+ libraries (React, Next.js, Vue, Express, Prisma, etc.)
+- On-demand fetching - retrieves documentation only when needed
+- Lightweight shell script implementation
 
 ### Coach
 Self-improving learning system that detects friction signals and proposes rule updates.


### PR DESCRIPTION
## Summary
- Add Context7 library documentation lookup skill to the marketplace
- Lightweight alternative to Context7 MCP with no persistent context overhead
- Fetches up-to-date documentation for 50+ libraries via REST API

## Changes
- `.github/workflows/sync-skills.yml`: Add sync step for context7-skill (now syncing 19 skills)
- `.claude-plugin/marketplace.json`: Add context7 plugin entry and to skills bundle
- `README.md`: Add skill to installed skills table and detailed section

## Source Repository
https://github.com/netresearch/context7-skill

## Test plan
- [ ] Verify workflow syncs context7-skill correctly
- [ ] Confirm marketplace.json is valid JSON
- [ ] Check README renders correctly with new skill