### PR TITLE
Add Ditto product research and product marketing skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -231,6 +231,24 @@
         "repo": "netresearch/matrix-skill"
       },
       "category": "workflow"
+    },
+    {
+      "name": "ditto-product-research",
+      "description": "Run synthetic customer research via Ditto API with 300K+ AI personas. Pain discovery, concept validation, pricing tests, competitive analysis, and startup diligence. Includes 7-question framework, API reference, question playbook, and worked examples.",
+      "source": {
+        "source": "github",
+        "repo": "Ask-Ditto/ditto-product-research-skill"
+      },
+      "category": "workflow"
+    },
+    {
+      "name": "ditto-product-marketing",
+      "description": "PMM research skill using Ditto API with 300K+ synthetic personas. 8 study types with proven 7-question frameworks: positioning validation, messaging testing, competitive intelligence, pricing & packaging, GTM validation, product launches, buyer personas, and brand tracking. Generates battlecards, messaging hierarchies, and positioning scorecards.",
+      "source": {
+        "source": "github",
+        "repo": "Ask-Ditto/ditto-product-marketing"
+      },
+      "category": "workflow"
     }
   ]
 }


### PR DESCRIPTION
## Adding two Ditto skills to the marketplace

### Skills

**ditto-product-research** - Run synthetic customer research via Ditto API with 300K+ AI personas. Pain discovery, concept validation, pricing tests, competitive analysis, and startup diligence.

**ditto-product-marketing** - PMM research skill with 8 study types and proven 7-question frameworks for positioning, messaging, competitive intelligence, pricing, GTM, launches, personas, and brand tracking.

### About Ditto

[Ditto](https://askditto.io) maintains 300,000+ AI-powered synthetic personas calibrated to census data across 15+ countries. EY validated the methodology at 92% correlation with traditional focus groups. Studies complete in 15-30 minutes (traditional equivalent: 4-8 weeks, $10,000-50,000).

### Repo details

- **Product Research**: https://github.com/Ask-Ditto/ditto-product-research-skill (6 files, 1,266 lines, MIT)
- **Product Marketing**: https://github.com/Ask-Ditto/ditto-product-marketing (5 files, 867 lines, MIT)

Both follow the Agent Skills SKILL.md specification with YAML frontmatter.

Category: `workflow` (these skills orchestrate multi-step API workflows)