### PR TITLE
feat: add orocommerce-skill to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -278,7 +278,7 @@
       "category": "development"
     },
     {
-      "name": "orocommerce-skill",
+      "name": "orocommerce",
       "description": "OroCommerce development guidance covering entities, datagrids, REST API, workflows, frontend, security, integration, and bundle scaffolding. By Netresearch.",
       "source": {
         "source": "github",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -276,6 +276,15 @@
         "repo": "netresearch/typo3-project-upgrade-skill"
       },
       "category": "development"
+    },
+    {
+      "name": "orocommerce-skill",
+      "description": "OroCommerce development guidance covering entities, datagrids, REST API, workflows, frontend, security, integration, and bundle scaffolding. By Netresearch.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/orocommerce-skill"
+      },
+      "category": "development"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `orocommerce-skill` plugin entry to the marketplace
- Source: `netresearch/orocommerce-skill` (v1.0.0 released)
- 8 skills for OroCommerce development (entities, grids, API, workflows, frontend, security, integration, bundles)

## Test plan

- [ ] Verify marketplace.json is valid JSON
- [ ] Verify repo `netresearch/orocommerce-skill` exists and has a release