### PR TITLE
feat: add github-release skill to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -312,6 +312,15 @@
         "repo": "netresearch/typo3-vite-skill"
       },
       "category": "development"
+    },
+    {
+      "name": "github-release",
+      "description": "Safe, automated GitHub releases with supply chain security. Prevents dangerous gh release commands, orchestrates version bumps, signed tags, and CI-driven releases across ecosystems.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/github-release-skill"
+      },
+      "category": "devops"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | go-development | [go-development-skill](https://github.com/netresearch/go-development-skill) | Production-grade Go patterns: testing, Docker, LDAP, resilience |
 | git-workflow | [git-workflow-skill](https://github.com/netresearch/git-workflow-skill) | Branching strategies, Conventional Commits, PR workflows |
 | github-project | [github-project-skill](https://github.com/netresearch/github-project-skill) | GitHub repo setup: branch protection, CODEOWNERS, auto-merge |
-| github-release | [github-release-skill](https://github.com/netresearch/github-release-skill) | Safe, automated GitHub releases with supply chain security |
+| github-release | [github-release-skill](https://github.com/netresearch/github-release-skill) | Safe, automated GitHub releases with supply chain security. Prevents dangerous gh release commands, orchestrates version bumps, signed tags, and CI-driven releases across ecosystems. |
 
 ### Productivity & Integration
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | go-development | [go-development-skill](https://github.com/netresearch/go-development-skill) | Production-grade Go patterns: testing, Docker, LDAP, resilience |
 | git-workflow | [git-workflow-skill](https://github.com/netresearch/git-workflow-skill) | Branching strategies, Conventional Commits, PR workflows |
 | github-project | [github-project-skill](https://github.com/netresearch/github-project-skill) | GitHub repo setup: branch protection, CODEOWNERS, auto-merge |
+| github-release | [github-release-skill](https://github.com/netresearch/github-release-skill) | Safe, automated GitHub releases with supply chain security |
 
 ### Productivity & Integration
 


### PR DESCRIPTION
## Summary

- Add `github-release` skill entry to `.claude-plugin/marketplace.json` pointing to `netresearch/github-release-skill`
- Add corresponding row in the DevOps & Infrastructure section of `README.md`

The skill provides safe, automated GitHub releases with supply chain security — prevents dangerous `gh release` commands, orchestrates version bumps, signed tags, and CI-driven releases across ecosystems.

## Test plan

- [ ] Verify `marketplace.json` is valid JSON
- [ ] Verify the skill repo exists at https://github.com/netresearch/github-release-skill
- [ ] Install via `/plugin` and confirm skill is listed