### PR TITLE
feat: add german-technical-writing skill to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -321,6 +321,15 @@
         "repo": "netresearch/github-release-skill"
       },
       "category": "devops"
+    },
+    {
+      "name": "german-technical-writing",
+      "description": "Enforce natural German technical register in Jira comments and descriptions, internal German-language documentation, and team-chat messages to German-speaking colleagues. Catches literal English→German anglicisms (brechen, gefangen, returnen, triggern, failen) and substitutes canonical technical verbs (werfen, abfangen, zurückgeben, auslösen, fehlschlagen) while accepting ecosystem-standard Denglisch loanwords (der Commit, die Pipeline, die Exception). Does not apply to commit messages, MR/PR descriptions, or release notes — those are English by team convention at Netresearch and most agencies delivering customer projects.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/german-technical-writing-skill"
+      },
+      "category": "workflow"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | file-search | [file-search-skill](https://github.com/netresearch/file-search-skill) | Efficient code search with ripgrep, ast-grep, fd |
 | pagerangers-seo | [pagerangers-skill](https://github.com/netresearch/pagerangers-skill) | PageRangers SEO API: keyword rankings, SERP analysis |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
+| german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 
 ### Meta
 


### PR DESCRIPTION
## Summary

- Add `german-technical-writing` skill entry to `.claude-plugin/marketplace.json` pointing to [`netresearch/german-technical-writing-skill`](https://github.com/netresearch/german-technical-writing-skill)
- Add corresponding row in the **Productivity & Integration** section of `README.md`

The skill enforces natural German technical register in **German-audience** artifacts — Jira comments and descriptions, internal German-language wiki/spec pages, and team-chat messages (Slack, Matrix, Teams) to German-speaking colleagues. It catches literal English→German translation anglicisms (`brechen`, `gefangen`, `returnen`, `triggern`, `failen`, `hitten`) and substitutes canonical technical verbs (`werfen`, `abfangen`, `zurückgeben`, `auslösen`, `fehlschlagen`, `auf … stoßen`), while accepting ecosystem-standard Denglisch loanwords (`der Commit`, `die Pipeline`, `die Exception`, `die Fixture`).

### Scope — what the skill explicitly does NOT cover

**Commit messages, MR/PR descriptions, and release notes** — at Netresearch and most agencies delivering customer projects, all three artifact types are written in English by team convention regardless of the team's native language. The skill's description explicitly excludes them from triggering.

### Sources

Built on the [Microsoft German Localization Style Guide](https://download.microsoft.com/download/e/f/9/ef9f6d8e-cd8b-420c-8696-afd98b4a367d/deu-deu-StyleGuide.pdf), Microsoft Learn German, Weka tekom guides, dictaJet, and an anti-pattern catalogue distilled from real Jira-comment failures.

### Category decision

`workflow` — matches the two other team-communication-artifact skills (`jira-integration`, `matrix-communication`). `productivity` was also considered (coach), but the skill is closer in function to the workflow-tagged plugins.

## Test plan

- [ ] Verify `marketplace.json` is valid JSON (`jq . .claude-plugin/marketplace.json` — now 36 plugins)
- [ ] Verify the skill repo exists at https://github.com/netresearch/german-technical-writing-skill
- [ ] Install via `/plugin install german-technical-writing` and confirm skill is listed in `available-skills`
- [ ] Trigger check: a German Jira-writing request should invoke the skill; a German commit / MR description / release-note request should NOT (per scope exclusion); an English request or German single-word reply should NOT