### PR TITLE
Add Skills宝 as a Chinese browse/install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ npx skills add https://github.com/netresearch/{repo-name} --skill {skill-name}
 
 Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ## Available Skills
 
 ### TYPO3 Development


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to search and install agent skills directly. This fits the repository browse/install focus and gives Chinese users a faster entry point to the existing skills marketplace.