### PR TITLE
feat: register peer-qa-review skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -330,6 +330,15 @@
         "repo": "netresearch/german-technical-writing-skill"
       },
       "category": "workflow"
+    },
+    {
+      "name": "peer-qa-review",
+      "description": "Round-1 IT QA peer-review runbook: lifecycle, checklist, severity vocabulary, structured Jira comment template, edge cases, anti-patterns. Triggers on tickets transitioned to QA status, 'ready for QA' comments, and explicit requests for IT QA / peer review / quality gate. Generic for any IT/Ops team; defers to internal team-specific skills for project-list, inventory, and announcement-channel overrides.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/peer-qa-review-skill"
+      },
+      "category": "workflow"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | pagerangers-seo | [pagerangers-skill](https://github.com/netresearch/pagerangers-skill) | PageRangers SEO API: keyword rankings, SERP analysis |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
+| peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |
 
 ### Meta
 


### PR DESCRIPTION
## Summary

Register the new public skill [`peer-qa-review`](https://github.com/netresearch/peer-qa-review-skill) — Round-1 IT QA peer-review runbook for any IT/Ops team.

## What it does

Round-1 QA is the **internal team review** of completed work *before* it goes to customer acceptance (Round-2 / QA2) or is resolved internally. Triggers on QA-status tickets, "ready for QA" comments, and explicit peer-review / quality-gate requests.

Provides:
- 6-stage lifecycle (Claim → Discover → Formal → Functional+Inventory → Docs+Rollback+Communication → Verdict → Comment+Transition)
- ~30 checks across 7 pillars (Formal / Functional / Inventory / Docs / Rollback / Communication / Process)
- Atlassian icon severity vocabulary `(/) (x) (!) (i) (?) (-)` with worked examples
- Jira-wiki comment template with three filled examples (pass / bounce / won't-do)
- 9 edge cases including won't-do path, self-review handoff, QA2 routing
- 20 anti-patterns drawn from empirical NR practice (NRS-4321, NRS-4356, NRT-4568, SRVGL-238, SRVOF-97, NRT-4567)

Generic for any IT/Ops team; defers to internal team-specific skills for project-list, inventory CRUD, and announcement-channel overrides via *"if your team has an internal IT/maintenance/ITSM skill, consult it"*.

## Companion change

Companion PR [jira-skill #80](https://github.com/netresearch/jira-skill/pull/80) adds `qa-gather.py` — a single-call discovery utility used in the skill's Stage 0. The skill also ships a `scripts/qa-gather.sh` wrapper that falls back to multi-call discovery if `qa-gather.py` isn't installed.

## Tracking

NRS-4380.