### PR TITLE
feat: add markdown-to-pdf and typo3-upgrade-effort-model skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -342,7 +342,7 @@
     },
     {
       "name": "markdown-to-pdf",
-      "description": "Convert Markdown files to styled PDFs using WeasyPrint. Generic, brand-neutral default styling with --css override for branded output (e.g., apply netresearch-branding-skill/assets/markdown-pdf.css for Netresearch-branded PDFs).",
+      "description": "Convert Markdown files to styled PDFs using WeasyPrint. Generic, brand-neutral default styling with --css override for branded output (e.g., apply the markdown-pdf.css asset shipped by netresearch-branding-skill for Netresearch-branded PDFs).",
       "source": {
         "source": "github",
         "repo": "netresearch/markdown-to-pdf-skill"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -348,6 +348,15 @@
         "repo": "netresearch/markdown-to-pdf-skill"
       },
       "category": "document"
+    },
+    {
+      "name": "typo3-upgrade-effort-model",
+      "description": "Generic effort model for TYPO3 LTS major version upgrades: per-version risk multipliers (v14: Fluid 5 strict VHs, HashService removal, TSFE removal, asset-pipeline removal), breaking-change baselines, version-compatibility matrix, Rector coverage adjustments, and a 7-phase assessment workflow. Calibration-free — pair with your team's historical project data for tuned estimates.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/typo3-upgrade-effort-model-skill"
+      },
+      "category": "development"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -339,6 +339,15 @@
         "repo": "netresearch/peer-qa-review-skill"
       },
       "category": "workflow"
+    },
+    {
+      "name": "markdown-to-pdf",
+      "description": "Convert Markdown files to styled PDFs using WeasyPrint. Generic, brand-neutral default styling with --css override for branded output (e.g., apply netresearch-branding-skill/assets/markdown-pdf.css for Netresearch-branded PDFs).",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/markdown-to-pdf-skill"
+      },
+      "category": "document"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |
+| markdown-to-pdf | [markdown-to-pdf-skill](https://github.com/netresearch/markdown-to-pdf-skill) | Convert Markdown files to styled PDFs via WeasyPrint; CSS-overridable for branded output |
+| typo3-upgrade-effort-model | [typo3-upgrade-effort-model-skill](https://github.com/netresearch/typo3-upgrade-effort-model-skill) | TYPO3 LTS upgrade effort model: risk multipliers, baselines, version compatibility, Rector coverage, 7-phase workflow |
 
 ### Meta
 


### PR DESCRIPTION
## Summary

Add two new public skills to the marketplace, both extracted from internal coding-ai skills as part of a public/private split.

### `markdown-to-pdf`

Generic Markdown→PDF conversion via WeasyPrint with neutral default CSS and `--css` override.

- Replaces internal `coding-ai/markdown-to-pdf-skill` (NR-themed default).
- Companion: `netresearch-branding-skill/assets/markdown-pdf.css` (added in [#26](https://github.com/netresearch/netresearch-branding-skill/pull/26)).
- Internal users install both and pass `--css` for branded output.
- Internal repo will be archived; coding-ai marketplace MR removes the entry: [coding-ai/marketplace!9](https://git.netresearch.de/coding-ai/marketplace/-/merge_requests/9).

### `typo3-upgrade-effort-model`

Generic TYPO3 LTS upgrade effort model — risk multipliers, breaking-change baselines, version-compatibility matrix, Rector coverage adjustments, 7-phase assessment workflow.

- Calibration-free: per-extension hour ranges; team calibration is supplied by the consuming internal skill.
- Companion: `coding-ai/typo3-upgrade-estimator-skill` will be rewritten to consume this public model + add NR-specific case studies and calibration constants.

## Test plan

- [x] JSON validates (39 plugins)
- [x] Both source repos exist and are public
- [x] No removal of existing entries