### PR TITLE
feat: add retro skill to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -357,6 +357,15 @@
         "repo": "netresearch/typo3-upgrade-effort-model-skill"
       },
       "category": "development"
+    },
+    {
+      "name": "retro",
+      "description": "LLM-driven session retrospection. Detects friction in agent sessions (mechanical pre-pass + LLM inference + cross-session) and materializes approved learnings into the correct destination (user memory, project rules, skill PRs, checkpoints, or harness artefacts). Provides /retro (sweep + spotlight), /retro outcome (post-hoc review of past session output), /retro audit (cross-session architectural review). Optional SessionEnd hook.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/retro-skill"
+      },
+      "category": "productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -360,7 +360,7 @@
     },
     {
       "name": "retro",
-      "description": "LLM-driven session retrospection. Detects friction in agent sessions (mechanical pre-pass + LLM inference + cross-session) and materializes approved learnings into the correct destination (user memory, project rules, skill PRs, checkpoints, or harness artefacts). Provides /retro (sweep + spotlight), /retro outcome (post-hoc review of past session output), /retro audit (cross-session architectural review). Optional SessionEnd hook.",
+      "description": "LLM-driven session retrospection. Detects friction in agent sessions (mechanical pre-pass + LLM inference + cross-session) and materializes approved learnings into the correct destination (user memory, project rules, skill PRs, checkpoints, or harness artifacts). Provides /retro (sweep + spotlight), /retro outcome (post-hoc review of past session output), /retro audit (cross-session architectural review). Optional SessionEnd hook.",
       "source": {
         "source": "github",
         "repo": "netresearch/retro-skill"

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | file-search | [file-search-skill](https://github.com/netresearch/file-search-skill) | Efficient code search with ripgrep, ast-grep, fd |
 | pagerangers-seo | [pagerangers-skill](https://github.com/netresearch/pagerangers-skill) | PageRangers SEO API: keyword rankings, SERP analysis |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
-| retro | [retro-skill](https://github.com/netresearch/retro-skill) | LLM-driven session retrospection: detects friction, materializes learnings into user memory / project rules / skill PRs / checkpoints. Includes `/retro outcome` and `/retro audit` modes |
+| retro | [retro-skill](https://github.com/netresearch/retro-skill) | LLM-driven session retrospection: detects friction and materializes learnings into user memory, project rules, skill PRs, checkpoints, or harness artifacts. Includes `/retro outcome` and `/retro audit` modes |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |
 | markdown-to-pdf | [markdown-to-pdf-skill](https://github.com/netresearch/markdown-to-pdf-skill) | Convert Markdown files to styled PDFs via WeasyPrint; CSS-overridable for branded output |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | file-search | [file-search-skill](https://github.com/netresearch/file-search-skill) | Efficient code search with ripgrep, ast-grep, fd |
 | pagerangers-seo | [pagerangers-skill](https://github.com/netresearch/pagerangers-skill) | PageRangers SEO API: keyword rankings, SERP analysis |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
+| retro | [retro-skill](https://github.com/netresearch/retro-skill) | LLM-driven session retrospection: detects friction, materializes learnings into user memory / project rules / skill PRs / checkpoints. Includes `/retro outcome` and `/retro audit` modes |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |
 | markdown-to-pdf | [markdown-to-pdf-skill](https://github.com/netresearch/markdown-to-pdf-skill) | Convert Markdown files to styled PDFs via WeasyPrint; CSS-overridable for branded output |


### PR DESCRIPTION
## Summary

Adds [`netresearch/retro-skill`](https://github.com/netresearch/retro-skill) v0.1.1 — LLM-driven session retrospection — as a new productivity-category entry in the marketplace.

## What retro-skill does

Detects friction in Claude Code sessions across **three detection layers**:
- **Schicht A — Mechanical** (Python pre-pass): 13 of 18 signals implemented (tool errors, retry clusters, output verbosity, user-correction phrases, prompt/tool sequence repetition, skill-not-triggered, re-reads, main-branch work, bot attribution, outdated tools, upstream failures)
- **Schicht B — LLM inference**: 14 inferential signals catalogued (wrong skill choice, hallucination, convention violations, repeated mistakes, doc drift, etc.)
- **Schicht C — Cross-session**: 5 signals via Coach events (optional) or session JSONL scan
- **Schicht D — Outcome** (catalogued, detectors v0.1.x): commits reverted, PRs rejected, CI failures, follow-up-fix sessions
- **Schicht E — Constitutional/audit** (catalogued, detectors v0.1.x): ADR violations, AGENTS.md compliance, coverage drift, skill-inventory bloat

Materializes approved learnings into one of six destinations: `user-memory`, `project-rule`, `skill-update`, `new-skill`, `checkpoint`, `harness-artefact`.

## Modes

```
/retro                               Sweep — full current session
/retro "<problem>"                   Spotlight — focus on one issue
/retro outcome [session-id|--since N] Post-hoc review of past session output
/retro audit [--scope X]              Cross-session architectural review
```

Plus optional SessionEnd hook (off by default).

## Companion changes (already merged)

This skill arrives with conventions defined in sibling skill repos:
- netresearch/agent-harness-skill#24 — AH-22/AH-23 checkpoints for retro integration verification
- netresearch/agent-rules-skill#48 — feedback-memory-schema as canonical project-rule format
- netresearch/skill-repo-skill#97 — materialization-contract for skill-update PRs + retro PR template
- netresearch/automated-assessment-skill#41 — learning-derived-checkpoints schema

## Change

- `.claude-plugin/marketplace.json`: +1 entry (`retro`, category: productivity); total 39 → 40 plugins
- `README.md`: +1 row in "Productivity & Integration" table, placed next to `coach` (closest conceptual sibling)

## Test plan

- [x] `jq -e . .claude-plugin/marketplace.json` passes
- [x] `bash scripts/validate.sh` reports "Marketplace valid: 40 plugins"
- [x] No duplicate plugin entries
- [x] retro-skill source repo is public + has plugin.json with `name: "retro"` (matching marketplace entry)