### PR TITLE
docs(agents): canonical categories, GitHub Pages policy, validator extensions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -270,7 +270,7 @@
     },
     {
       "name": "typo3-project-upgrade",
-      "description": "Systematic TYPO3 project instance upgrades across major LTS versions. Covers sys_template to Site Sets migration, SCSS variable injection via Bootstrap Package ScssParser, Bootstrap 4 to 5 migration patterns (color-contrast, link-decoration, frame custom properties), Bootstrap Package v12-v16 breaking changes (navigation, position:sticky, dropdown-hover), Docker infrastructure (ImageMagick, GFX config), database cleanup, and visual review methodology. Includes assessment checkpoints for the extension-assessment framework.",
+      "description": "Systematic TYPO3 project instance upgrades across major LTS versions. Covers sys_template to Site Sets migration, Bootstrap 4 to 5 patterns, Bootstrap Package v12–v16 breaking changes, SCSS variable injection, Docker infrastructure, database cleanup, and visual review methodology. Includes assessment checkpoints.",
       "source": {
         "source": "github",
         "repo": "netresearch/typo3-project-upgrade-skill"
@@ -324,7 +324,7 @@
     },
     {
       "name": "german-technical-writing",
-      "description": "Enforce natural German technical register in Jira comments and descriptions, internal German-language documentation, and team-chat messages to German-speaking colleagues. Catches literal English→German anglicisms (brechen, gefangen, returnen, triggern, failen) and substitutes canonical technical verbs (werfen, abfangen, zurückgeben, auslösen, fehlschlagen) while accepting ecosystem-standard Denglisch loanwords (der Commit, die Pipeline, die Exception). Does not apply to commit messages, MR/PR descriptions, or release notes — those are English by team convention at Netresearch and most agencies delivering customer projects.",
+      "description": "Enforce natural German technical register in Jira tickets, internal German docs and team-chat to German-speaking colleagues. Catches English→German anglicisms (brechen, gefangen, returnen, triggern, failen) and substitutes canonical verbs (werfen, abfangen, zurückgeben, auslösen, fehlschlagen) while accepting Denglisch loanwords (der Commit, die Pipeline, die Exception). Does not apply to commit messages or release notes.",
       "source": {
         "source": "github",
         "repo": "netresearch/german-technical-writing-skill"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,16 @@ Each skill entry in the marketplace (whether represented as JSON, YAML, tables i
 
 ---
 
+## Canonical categories
+
+Use **exactly one** of these values in `plugins[].category` — do not invent new categories without updating this file, the README catalog grouping, and any future landingpage/sitemap generator:
+
+`development` · `devops` · `security` · `design` · `workflow` · `productivity` · `document`
+
+`scripts/validate.sh` enforces this enum. Skill repositories should keep their `discovery.yaml` `category` field in sync. When a new category is genuinely required, propose it in a PR that updates this list, the validator's allowed set, and the README catalog grouping.
+
+---
+
 ## SEO and discovery rules (marketplace copy)
 
 Marketplace-facing text **must**:
@@ -56,6 +66,7 @@ Marketplace-facing text **must**:
 - **Name technologies explicitly** where applicable, e.g. TYPO3, PHP, OroCommerce, Jira, GitHub, Docker, Concourse, SEO, Security, Accessibility, Vite.
 - **Expose one indexable detail surface per skill** (unique heading + stable path; no duplicate canonical URLs for the same skill).
 - **Support internal linking** via Related Skills and use-case hubs (markdown links or generated link graph — implementation-specific).
+- **Stay snippet-friendly:** `plugins[].description` targets ≤ **300 characters** and is **hard-capped at 500**. `scripts/validate.sh` warns on the target and fails on the hard cap. Long-form content belongs on the dedicated landing or the source README — never copied into the marketplace description.
 
 ---
 
@@ -78,6 +89,25 @@ A skill **must not** appear isolated in the marketplace. Every listed skill **mu
 - The marketplace **aggregates, normalizes, and displays** that information for discovery and installation.
 - **Avoid duplicate truths**: do not restate long procedural docs from `SKILL.md` in the marketplace; summarize and link.
 - **On conflict** between marketplace copy and the skill repo: **fix the skill repo** OR **document an intentional marketplace override** (where, why, effective date). Silent divergence is not allowed.
+
+---
+
+## GitHub Pages policy
+
+The **marketplace repository SHOULD publish a GitHub Pages site** as the canonical public discovery and storytelling layer for Netresearch Agent Skills — hub pages, per-slug landings, related-skills crosslinks, sitemaps, OpenGraph metadata.
+
+Individual **skill repositories MUST NOT enable GitHub Pages by default**. A skill repo may enable Pages only when the criteria in [`skill-repo-skill`/`references/repository-quality-rules.md`](https://github.com/netresearch/skill-repo-skill/blob/main/skills/skill-repo/references/repository-quality-rules.md) are satisfied (multi-page docs, gallery, generated reference, versioned docs, public reference implementation, methodology/assessment model, or a distinct SEO target the marketplace landing cannot cover).
+
+Mirroring rule: skill-specific metadata originates in the skill repository (`discovery.yaml` or README sections). The marketplace consumes it. Do not duplicate the same metadata across README, a skill-repo Pages site and the marketplace landing — pick one canonical surface per fact and link from the others.
+
+---
+
+## Known marketplace overrides
+
+Record intentional deviations from a source skill repo. Empty by default.
+
+| Slug | Field | Marketplace value | Reason | Decided |
+|---|---|---|---|---|
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Each skill entry in the marketplace (whether represented as JSON, YAML, tables i
 
 ## Canonical categories
 
-Use **exactly one** of these values in `plugins[].category` — do not invent new categories without updating this file, the README catalog grouping, and any future landingpage/sitemap generator:
+Use **exactly one** of these values in `plugins[].category` — do not invent new categories without updating this file, the README catalog grouping, and any future landing-page/sitemap generator:
 
 `development` · `devops` · `security` · `design` · `workflow` · `productivity` · `document`
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Browse all skills at [skills.sh/netresearch](https://skills.sh/netresearch).
 | typo3-frontend-patterns | [typo3-frontend-patterns-skill](https://github.com/netresearch/typo3-frontend-patterns-skill) | Reusable frontend patterns (sticky header, breadcrumb, lazy loading) |
 | typo3-vite | [typo3-vite-skill](https://github.com/netresearch/typo3-vite-skill) | Vite build setup, SCSS architecture, Bootstrap 5 theming |
 
+### OroCommerce
+
+| Skill | Repository | Description |
+|-------|-----------|-------------|
+| orocommerce | [orocommerce-skill](https://github.com/netresearch/orocommerce-skill) | OroCommerce development: entities, datagrids, REST API, workflows, frontend, security, integration, bundle scaffolding |
+
 ### Code Quality & Security
 
 | Skill | Repository | Description |

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -102,21 +102,23 @@ if [ -n "$DUPE_DESC" ]; then
     printf '%s\n' "$DUPE_DESC" | sed 's/^/    /'
     exit 1
 fi
-echo "✓ Descriptions present, unique, within hard cap"
+echo "✓ Descriptions: present, ≤ 500 hard cap, unique (warnings printed for entries over the 300-char snippet target)"
 
-# README catalog row must exist for every plugin (anchor reachability).
+# README catalog row must exist for every plugin. The README uses Markdown
+# tables, so we require the slug to appear as a table cell ('| <slug> |')
+# to avoid false positives from substring matches elsewhere in prose or URLs.
 if [ -f README.md ]; then
     MISSING_README=$(jq -r '.plugins[].name' "$MARKETPLACE" | while read -r slug; do
-        if ! grep -q "$slug" README.md; then
+        if ! grep -qE "^\| *${slug} *\|" README.md; then
             echo "$slug"
         fi
     done)
     if [ -n "$MISSING_README" ]; then
-        echo "✗ Plugins missing from README catalog:"
+        echo "✗ Plugins missing a catalog row in README (expected '| <slug> |' table cell):"
         printf '%s\n' "$MISSING_README" | sed 's/^/    /'
         exit 1
     fi
-    echo "✓ Every plugin referenced in README"
+    echo "✓ Every plugin has a README catalog row"
 fi
 
 # Summary

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Validate marketplace.json structure and content
-# Used by: pre-commit hook, CI workflow
+# Validate marketplace.json structure and content.
+# Used by: pre-commit hook, CI workflow.
+# Mechanical guard for the rules in AGENTS.md.
 
 set -e
 
@@ -31,13 +32,92 @@ if ! jq -e '
 fi
 echo "✓ Valid structure"
 
-# Check for duplicates
+# Check for duplicate slugs
 DUPES=$(jq -r '.plugins[].name' "$MARKETPLACE" | sort | uniq -d)
 if [ -n "$DUPES" ]; then
     echo "✗ Duplicate plugin names: $DUPES"
     exit 1
 fi
 echo "✓ No duplicate plugins"
+
+# Canonical categories — keep in sync with AGENTS.md.
+ALLOWED_CATEGORIES='development devops security design workflow productivity document'
+BAD_CATEGORIES=$(jq -r --arg allowed "$ALLOWED_CATEGORIES" '
+    [.plugins[] | select((.category // "") as $c | ($allowed | split(" ")) | index($c) | not)
+                | "\(.name)=\(.category // "<missing>")"]
+    | join("\n")
+' "$MARKETPLACE")
+if [ -n "$BAD_CATEGORIES" ]; then
+    echo "✗ Non-canonical categories (allowed: $ALLOWED_CATEGORIES):"
+    printf '%s\n' "$BAD_CATEGORIES" | sed 's/^/    /'
+    exit 1
+fi
+echo "✓ Categories within canonical set"
+
+# Slugs must be lowercase / hyphens / ≤ 64 chars.
+BAD_SLUGS=$(jq -r '
+    [.plugins[].name | select(test("^[a-z0-9][a-z0-9-]{0,63}$") | not)]
+    | join("\n")
+' "$MARKETPLACE")
+if [ -n "$BAD_SLUGS" ]; then
+    echo "✗ Invalid slugs (must match ^[a-z0-9][a-z0-9-]{0,63}\$):"
+    printf '%s\n' "$BAD_SLUGS" | sed 's/^/    /'
+    exit 1
+fi
+echo "✓ Slugs well-formed"
+
+# Description rules: present, hard cap 500, target ≤ 300 (warning), unique.
+DESC_HARD=$(jq -r '
+    [.plugins[]
+        | . as $p
+        | (.description // "") as $d
+        | if ($d | length) == 0 then
+            "\($p.name): missing description"
+          elif ($d | length) > 500 then
+            "\($p.name): description \($d | length) chars (> 500 hard cap)"
+          else empty end]
+    | join("\n")
+' "$MARKETPLACE")
+if [ -n "$DESC_HARD" ]; then
+    echo "✗ Description rules violated:"
+    printf '%s\n' "$DESC_HARD" | sed 's/^/    /'
+    exit 1
+fi
+DESC_WARN=$(jq -r '
+    [.plugins[]
+        | . as $p
+        | (.description // "") as $d
+        | if ($d | length) > 300 then
+            "\($p.name): description \($d | length) chars (> 300 target)"
+          else empty end]
+    | join("\n")
+' "$MARKETPLACE")
+if [ -n "$DESC_WARN" ]; then
+    echo "⚠ Descriptions over snippet-friendly target (≤ 300):"
+    printf '%s\n' "$DESC_WARN" | sed 's/^/    /'
+fi
+DUPE_DESC=$(jq -r '[.plugins[].description] | group_by(.) | map(select(length>1) | .[0]) | join("\n")' "$MARKETPLACE")
+if [ -n "$DUPE_DESC" ]; then
+    echo "✗ Duplicate descriptions across plugins (must be unique):"
+    printf '%s\n' "$DUPE_DESC" | sed 's/^/    /'
+    exit 1
+fi
+echo "✓ Descriptions present, unique, within hard cap"
+
+# README catalog row must exist for every plugin (anchor reachability).
+if [ -f README.md ]; then
+    MISSING_README=$(jq -r '.plugins[].name' "$MARKETPLACE" | while read -r slug; do
+        if ! grep -q "$slug" README.md; then
+            echo "$slug"
+        fi
+    done)
+    if [ -n "$MISSING_README" ]; then
+        echo "✗ Plugins missing from README catalog:"
+        printf '%s\n' "$MISSING_README" | sed 's/^/    /'
+        exit 1
+    fi
+    echo "✓ Every plugin referenced in README"
+fi
 
 # Summary
 COUNT=$(jq '.plugins | length' "$MARKETPLACE")


### PR DESCRIPTION
## Summary

Layered on top of the existing `AGENTS.md` (PR #38 / origin/main). Adds the bits that were missing: a pinned category enum, GitHub Pages policy, a known-deviations table, and mechanical guards in `scripts/validate.sh`.

## What changes

### `AGENTS.md`

- **Canonical categories** — pins the allowed enum (`development`, `devops`, `security`, `design`, `workflow`, `productivity`, `document`) with a process for adding new ones.
- **SEO snippet rule** — description target ≤ 300 chars, hard cap 500.
- **GitHub Pages policy** — marketplace is the canonical Pages site; skill repos default to Pages disabled; mirroring rule.
- **Known marketplace overrides** — placeholder table for documenting intentional deviations from source skill repos.

### `scripts/validate.sh`

- Canonical-category enum check.
- Slug shape (`^[a-z0-9][a-z0-9-]{0,63}\$`).
- Description present, ≤ 500 hard cap (error), ≤ 300 target (warning), unique across plugins.
- Every plugin slug must be referenced in the README catalog.

### Catalog hygiene

- Trims two over-hard-cap descriptions into snippet-friendly form (`typo3-project-upgrade`, `german-technical-writing`).
- Adds the previously orphan `orocommerce` plugin to a new **OroCommerce** README section so catalog-reachability passes.

## Paired PR

Per-skill discovery/quality rules: [`netresearch/skill-repo-skill#98`](https://github.com/netresearch/skill-repo-skill/pull/98).

## Test plan

- [x] `./scripts/validate.sh` exits 0 (warnings flag 15 over-target descriptions for future trim).
- [x] `jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort | uniq -d` empty.
- [x] All 40 plugins reachable in README.