### PR TITLE
fix(pages): correct path prefix — assets + redirect resolved off-project

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -107,11 +107,12 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Stage built site at workspace root for lhci
+      - name: Stage built site under deploy prefix for lhci
         working-directory: ${{ github.workspace }}
         run: |
-          cp -r site/_site .lhci-site
-          ls -la .lhci-site/en/ | head
+          mkdir -p .lhci-site
+          cp -r site/_site .lhci-site/claude-code-marketplace
+          ls -la .lhci-site/claude-code-marketplace/en/ | head
 
       - name: Lighthouse CI
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # 12.6.2

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,12 +3,12 @@
     "collect": {
       "staticDistDir": "./.lhci-site",
       "url": [
-        "http://localhost/en/index.html",
-        "http://localhost/de/index.html",
-        "http://localhost/en/skills/typo3-conformance/index.html",
-        "http://localhost/en/skills/php-modernization/index.html",
-        "http://localhost/en/skills/security-audit/index.html",
-        "http://localhost/de/skills/typo3-conformance/index.html"
+        "http://localhost/claude-code-marketplace/en/",
+        "http://localhost/claude-code-marketplace/de/",
+        "http://localhost/claude-code-marketplace/en/skills/typo3-conformance/",
+        "http://localhost/claude-code-marketplace/en/skills/php-modernization/",
+        "http://localhost/claude-code-marketplace/en/skills/security-audit/",
+        "http://localhost/claude-code-marketplace/de/skills/typo3-conformance/"
       ],
       "numberOfRuns": 1,
       "settings": {

--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -41,5 +41,10 @@ export default function (eleventyConfig) {
     templateFormats: ["njk", "md", "html"],
     markdownTemplateEngine: "njk",
     htmlTemplateEngine: "njk",
+    // Project Pages deploy lives at https://netresearch.github.io/claude-code-marketplace/
+    // pathPrefix tells the `| url` filter to prepend this to every root-relative path.
+    // Override at build time with PATH_PREFIX env var when serving from a different mount
+    // (e.g. for local preview at root).
+    pathPrefix: process.env.PATH_PREFIX ?? "/claude-code-marketplace/",
   };
 }

--- a/site/src/_data/site.json
+++ b/site/src/_data/site.json
@@ -1,7 +1,7 @@
 {
   "title": "Netresearch Skills Marketplace",
   "tagline": "Curated Agent Skills for AI-assisted development",
-  "url": "https://netresearch.github.io/claude-code-marketplace",
+  "url": "https://netresearch.github.io",
   "repoUrl": "https://github.com/netresearch/claude-code-marketplace",
   "ownerUrl": "https://www.netresearch.de",
   "defaultLang": "en"

--- a/site/src/_includes/layouts/base.njk
+++ b/site/src/_includes/layouts/base.njk
@@ -8,28 +8,28 @@
     <meta name="theme-color" content="#2F99A4" />
     {% if robots %}<meta name="robots" content="{{ robots }}" />{% endif %}
 
-    <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+    <link rel="canonical" href="{{ site.url }}{{ page.url | url }}" />
     {% if hreflangAlternate %}
-      <link rel="alternate" hreflang="{{ hreflangAlternate.lang }}" href="{{ site.url }}{{ hreflangAlternate.url }}" />
-      <link rel="alternate" hreflang="{{ lang }}" href="{{ site.url }}{{ page.url }}" />
-      <link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ xDefaultUrl or '/en/' }}" />
+      <link rel="alternate" hreflang="{{ hreflangAlternate.lang }}" href="{{ site.url }}{{ hreflangAlternate.url | url }}" />
+      <link rel="alternate" hreflang="{{ lang }}" href="{{ site.url }}{{ page.url | url }}" />
+      <link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ (xDefaultUrl or '/en/') | url }}" />
     {% endif %}
 
     <meta property="og:type" content="{{ ogType or 'website' }}" />
     <meta property="og:title" content="{{ title or site.title }}" />
     <meta property="og:description" content="{{ description or site.tagline }}" />
-    <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
+    <meta property="og:url" content="{{ site.url }}{{ page.url | url }}" />
     <meta property="og:locale" content="{{ ogLocale or 'en_US' }}" />
-    <meta property="og:image" content="{{ site.url }}{{ ogImage or '/assets/og/landing.png' }}" />
+    <meta property="og:image" content="{{ site.url }}{{ (ogImage or '/assets/og/landing.png') | url }}" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     {% if hreflangAlternate %}
       <meta property="og:locale:alternate" content="{{ hreflangAlternate.ogLocale }}" />
     {% endif %}
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="{{ site.url }}{{ ogImage or '/assets/og/landing.png' }}" />
+    <meta name="twitter:image" content="{{ site.url }}{{ (ogImage or '/assets/og/landing.png') | url }}" />
 
-    <link rel="stylesheet" href="/assets/css/main.css" />
+    <link rel="stylesheet" href="{{ '/assets/css/main.css' | url }}" />
 
     <script type="application/ld+json">
       {
@@ -46,13 +46,13 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="site-header__brand" href="/{{ lang or 'en' }}/">
+      <a class="site-header__brand" href="{{ ('/' + (lang or 'en') + '/') | url }}">
         <strong>Netresearch</strong> Skills Marketplace
       </a>
       <nav class="site-header__nav" aria-label="Primary">
-        <a href="/{{ lang or 'en' }}/">{{ t.nav.home }}</a>
+        <a href="{{ ('/' + (lang or 'en') + '/') | url }}">{{ t.nav.home }}</a>
         {% if hreflangAlternate %}
-          <a href="{{ hreflangAlternate.url }}" hreflang="{{ hreflangAlternate.lang }}" rel="alternate">{{ t.nav.switchLang }}</a>
+          <a href="{{ hreflangAlternate.url | url }}" hreflang="{{ hreflangAlternate.lang }}" rel="alternate">{{ t.nav.switchLang }}</a>
         {% endif %}
       </nav>
     </header>
@@ -73,6 +73,6 @@
       </p>
     </footer>
 
-    <script src="/assets/js/enhance.js" defer></script>
+    <script src="{{ '/assets/js/enhance.js' | url }}" defer></script>
   </body>
 </html>

--- a/site/src/_includes/layouts/base.njk
+++ b/site/src/_includes/layouts/base.njk
@@ -46,11 +46,11 @@
   </head>
   <body>
     <header class="site-header">
-      <a class="site-header__brand" href="{{ ('/' + (lang or 'en') + '/') | url }}">
+      <a class="site-header__brand" href="{{ ('/' ~ (lang or 'en') ~ '/') | url }}">
         <strong>Netresearch</strong> Skills Marketplace
       </a>
       <nav class="site-header__nav" aria-label="Primary">
-        <a href="{{ ('/' + (lang or 'en') + '/') | url }}">{{ t.nav.home }}</a>
+        <a href="{{ ('/' ~ (lang or 'en') ~ '/') | url }}">{{ t.nav.home }}</a>
         {% if hreflangAlternate %}
           <a href="{{ hreflangAlternate.url | url }}" hreflang="{{ hreflangAlternate.lang }}" rel="alternate">{{ t.nav.switchLang }}</a>
         {% endif %}

--- a/site/src/_includes/layouts/skill.njk
+++ b/site/src/_includes/layouts/skill.njk
@@ -6,8 +6,8 @@ layout: layouts/base.njk
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <ol>
-    <li><a href="{{ ('/' + lang + '/') | url }}">{{ t.nav.home }}</a></li>
-    <li><a href="{{ ('/' + lang + '/#group-' + (skill.group or 'meta')) | url }}">{{ t.nav.skills }}</a></li>
+    <li><a href="{{ ('/' ~ lang ~ '/') | url }}">{{ t.nav.home }}</a></li>
+    <li><a href="{{ ('/' ~ lang ~ '/#group-' ~ (skill.group or 'meta')) | url }}">{{ t.nav.skills }}</a></li>
     <li aria-current="page">{{ skill.displayName }}</li>
   </ol>
 </nav>
@@ -71,7 +71,7 @@ layout: layouts/base.njk
             {% if related %}
               {% set relatedCatLabel = related.categoryLabelDe if lang == 'de' else related.categoryLabelEn %}
               <li>
-                <a href="{{ ('/' + lang + '/skills/' + related.slug + '/') | url }}">{{ related.displayName }}</a>
+                <a href="{{ ('/' ~ lang ~ '/skills/' ~ related.slug ~ '/') | url }}">{{ related.displayName }}</a>
                 <span class="related-list__cat">{{ relatedCatLabel }}</span>
               </li>
             {% else %}
@@ -115,7 +115,7 @@ layout: layouts/base.njk
   "description": description,
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "url": site.url + (page.url | url),
+  "url": site.url ~ (page.url | url),
   "sameAs": skill.repoUrl,
   "softwareHelp": skill.readmeUrl,
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -133,8 +133,8 @@ layout: layouts/base.njk
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   "itemListElement": [
-    { "@type": "ListItem", "position": 1, "name": t.nav.home, "item": site.url + ("/" + lang + "/" | url) },
-    { "@type": "ListItem", "position": 2, "name": categoryLabel, "item": site.url + ("/" + lang + "/#group-" + (skill.group or "meta") | url) },
+    { "@type": "ListItem", "position": 1, "name": t.nav.home, "item": site.url ~ (("/" ~ lang ~ "/") | url) },
+    { "@type": "ListItem", "position": 2, "name": categoryLabel, "item": site.url ~ (("/" ~ lang ~ "/#group-" ~ (skill.group or "meta")) | url) },
     { "@type": "ListItem", "position": 3, "name": skill.displayName }
   ]
 } | dump(2) | safe }}

--- a/site/src/_includes/layouts/skill.njk
+++ b/site/src/_includes/layouts/skill.njk
@@ -6,8 +6,8 @@ layout: layouts/base.njk
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <ol>
-    <li><a href="/{{ lang }}/">{{ t.nav.home }}</a></li>
-    <li><a href="/{{ lang }}/#group-{{ skill.group or 'meta' }}">{{ t.nav.skills }}</a></li>
+    <li><a href="{{ ('/' + lang + '/') | url }}">{{ t.nav.home }}</a></li>
+    <li><a href="{{ ('/' + lang + '/#group-' + (skill.group or 'meta')) | url }}">{{ t.nav.skills }}</a></li>
     <li aria-current="page">{{ skill.displayName }}</li>
   </ol>
 </nav>
@@ -71,7 +71,7 @@ layout: layouts/base.njk
             {% if related %}
               {% set relatedCatLabel = related.categoryLabelDe if lang == 'de' else related.categoryLabelEn %}
               <li>
-                <a href="/{{ lang }}/skills/{{ related.slug }}/">{{ related.displayName }}</a>
+                <a href="{{ ('/' + lang + '/skills/' + related.slug + '/') | url }}">{{ related.displayName }}</a>
                 <span class="related-list__cat">{{ relatedCatLabel }}</span>
               </li>
             {% else %}
@@ -115,7 +115,7 @@ layout: layouts/base.njk
   "description": description,
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "url": site.url + page.url,
+  "url": site.url + (page.url | url),
   "sameAs": skill.repoUrl,
   "softwareHelp": skill.readmeUrl,
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -133,8 +133,8 @@ layout: layouts/base.njk
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   "itemListElement": [
-    { "@type": "ListItem", "position": 1, "name": t.nav.home, "item": site.url + "/" + lang + "/" },
-    { "@type": "ListItem", "position": 2, "name": skill.categoryLabel, "item": site.url + "/" + lang + "/#group-" + (skill.group or "meta") },
+    { "@type": "ListItem", "position": 1, "name": t.nav.home, "item": site.url + ("/" + lang + "/" | url) },
+    { "@type": "ListItem", "position": 2, "name": categoryLabel, "item": site.url + ("/" + lang + "/#group-" + (skill.group or "meta") | url) },
     { "@type": "ListItem", "position": 3, "name": skill.displayName }
   ]
 } | dump(2) | safe }}

--- a/site/src/_includes/partials/skill-card.njk
+++ b/site/src/_includes/partials/skill-card.njk
@@ -1,7 +1,7 @@
 <article class="skill-card">
   <span class="skill-card__category" aria-label="Category">{{ categoryLabels[skill.category] or skill.category }}</span>
   <h3 class="skill-card__title">
-    <a href="/{{ lang }}/skills/{{ skill.slug }}/">{{ skill.slug | titleCase }}</a>
+    <a href="{{ ('/' + lang + '/skills/' + skill.slug + '/') | url }}">{{ skill.slug | titleCase }}</a>
   </h3>
   <p class="skill-card__description">{{ skill.description }}</p>
   <footer class="skill-card__footer">

--- a/site/src/_includes/partials/skill-card.njk
+++ b/site/src/_includes/partials/skill-card.njk
@@ -1,7 +1,7 @@
 <article class="skill-card">
   <span class="skill-card__category" aria-label="Category">{{ categoryLabels[skill.category] or skill.category }}</span>
   <h3 class="skill-card__title">
-    <a href="{{ ('/' + lang + '/skills/' + skill.slug + '/') | url }}">{{ skill.slug | titleCase }}</a>
+    <a href="{{ ('/' ~ lang ~ '/skills/' ~ skill.slug ~ '/') | url }}">{{ skill.slug | titleCase }}</a>
   </h3>
   <p class="skill-card__description">{{ skill.description }}</p>
   <footer class="skill-card__footer">

--- a/site/src/de/404.njk
+++ b/site/src/de/404.njk
@@ -9,7 +9,7 @@ robots: "noindex"
   <h1>Nicht gefunden</h1>
   <p class="lead">Diese Seite existiert (nicht mehr). Zurück zum Katalog mit den 40 kuratierten Skills.</p>
   <ul class="cta-links">
-    <li><a href="/de/">Skills-Katalog</a></li>
+    <li><a href="{{ '/de/' | url }}">Skills-Katalog</a></li>
     <li><a href="{{ site.repoUrl }}" rel="noopener">Auf GitHub ansehen</a></li>
   </ul>
 </section>

--- a/site/src/en/404.njk
+++ b/site/src/en/404.njk
@@ -9,7 +9,7 @@ robots: "noindex"
   <h1>Not found</h1>
   <p class="lead">That page does not exist (any longer). Head back to the catalog and browse the 40 curated skills.</p>
   <ul class="cta-links">
-    <li><a href="/en/">Skills catalog</a></li>
+    <li><a href="{{ '/en/' | url }}">Skills catalog</a></li>
     <li><a href="{{ site.repoUrl }}" rel="noopener">View on GitHub</a></li>
   </ul>
 </section>

--- a/site/src/index.njk
+++ b/site/src/index.njk
@@ -2,15 +2,17 @@
 permalink: /index.html
 eleventyExcludeFromCollections: true
 ---
+{%- set enUrl = '/en/' | url -%}
+{%- set deUrl = '/de/' | url -%}
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=/en/" />
-    <link rel="canonical" href="https://netresearch.github.io/claude-code-marketplace/en/" />
-    <link rel="alternate" hreflang="en" href="https://netresearch.github.io/claude-code-marketplace/en/" />
-    <link rel="alternate" hreflang="de" href="https://netresearch.github.io/claude-code-marketplace/de/" />
-    <link rel="alternate" hreflang="x-default" href="https://netresearch.github.io/claude-code-marketplace/en/" />
+    <meta http-equiv="refresh" content="0; url={{ enUrl }}" />
+    <link rel="canonical" href="{{ site.url }}{{ enUrl }}" />
+    <link rel="alternate" hreflang="en" href="{{ site.url }}{{ enUrl }}" />
+    <link rel="alternate" hreflang="de" href="{{ site.url }}{{ deUrl }}" />
+    <link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ enUrl }}" />
     <title>Netresearch Skills Marketplace</title>
     <meta name="robots" content="noindex" />
     <script>
@@ -19,14 +21,14 @@ eleventyExcludeFromCollections: true
       (function () {
         var lang = (navigator.language || "en").toLowerCase();
         if (lang.indexOf("de") === 0) {
-          window.location.replace("/de/");
+          window.location.replace({{ deUrl | dump | safe }});
         } else {
-          window.location.replace("/en/");
+          window.location.replace({{ enUrl | dump | safe }});
         }
       })();
     </script>
   </head>
   <body>
-    <p>Redirecting to <a href="/en/">English</a> or <a href="/de/">Deutsch</a>…</p>
+    <p>Redirecting to <a href="{{ enUrl }}">English</a> or <a href="{{ deUrl }}">Deutsch</a>…</p>
   </body>
 </html>

--- a/site/src/robots.txt.njk
+++ b/site/src/robots.txt.njk
@@ -5,4 +5,4 @@ eleventyExcludeFromCollections: true
 User-agent: *
 Allow: /
 
-Sitemap: {{ site.url }}/sitemap.xml
+Sitemap: {{ site.url }}{{ '/sitemap.xml' | url }}

--- a/site/src/sitemap.xml.njk
+++ b/site/src/sitemap.xml.njk
@@ -2,38 +2,42 @@
 permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
 ---
+{%- set enLanding = '/en/' | url -%}
+{%- set deLanding = '/de/' | url -%}
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>{{ site.url }}/en/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}/en/" />
-    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}/en/" />
+    <loc>{{ site.url }}{{ enLanding }}</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}{{ enLanding }}" />
+    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}{{ deLanding }}" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ enLanding }}" />
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>{{ site.url }}/de/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}/en/" />
-    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}/en/" />
+    <loc>{{ site.url }}{{ deLanding }}</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}{{ enLanding }}" />
+    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}{{ deLanding }}" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ enLanding }}" />
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   {% for skill in skills %}
+  {%- set enSkill = ('/en/skills/' + skill.slug + '/') | url -%}
+  {%- set deSkill = ('/de/skills/' + skill.slug + '/') | url -%}
   <url>
-    <loc>{{ site.url }}/en/skills/{{ skill.slug }}/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}/en/skills/{{ skill.slug }}/" />
-    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}/de/skills/{{ skill.slug }}/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}/en/skills/{{ skill.slug }}/" />
+    <loc>{{ site.url }}{{ enSkill }}</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}{{ enSkill }}" />
+    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}{{ deSkill }}" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ enSkill }}" />
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>{{ site.url }}/de/skills/{{ skill.slug }}/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}/en/skills/{{ skill.slug }}/" />
-    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}/de/skills/{{ skill.slug }}/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}/en/skills/{{ skill.slug }}/" />
+    <loc>{{ site.url }}{{ deSkill }}</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="{{ site.url }}{{ enSkill }}" />
+    <xhtml:link rel="alternate" hreflang="de" href="{{ site.url }}{{ deSkill }}" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="{{ site.url }}{{ enSkill }}" />
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Problem (live regression after #44 merge)

Reported by Sebastian after the merge: `https://netresearch.github.io/claude-code-marketplace/` bounced visitors to `https://netresearch.github.io/en/` (org root, not project) and the EN landing 404'd on CSS + JS:

```
en/:32  GET https://netresearch.github.io/assets/css/main.css net::ERR_ABORTED 404
en/:793 GET https://netresearch.github.io/assets/js/enhance.js net::ERR_ABORTED 404
```

## Cause

The site is served as a **project Pages** site under `/claude-code-marketplace/`, but every internal href and src was emitted as a root-relative path (`/en/`, `/assets/css/main.css`, …). On GitHub Pages those resolve against the **org root**, not the project URL. The root `/index.html` meta-refresh fired `0; url=/en/` which redirected straight out of the project.

## Fix

Eleventy `pathPrefix` + `| url` filter on every internal path.

- `site/.eleventy.js`: `pathPrefix: "/claude-code-marketplace/"`, overridable via `PATH_PREFIX` env (used by local previews from root)
- `site/src/_data/site.json`: `site.url` reduced to `https://netresearch.github.io` (host only); the project prefix flows in once through `| url`, no more double-prefix risk
- All templates threaded through `| url`: base layout (stylesheet, script, header, lang switcher, OG/Twitter image, og:url), root redirect (meta-refresh + JS + canonical + 3 hreflangs + fallback links), skill-card, skill detail layout (breadcrumb + related-skill cards + JSON-LD `url`), sitemap, robots, both 404s
- `.github/workflows/pages.yml`: lighthouse staging directory mirrors the deploy prefix (`/.lhci-site/claude-code-marketplace/...`) so the lhci static server mounts at the same URL prefix as prod
- `lighthouserc.json`: target URLs use `/claude-code-marketplace/...`

## Verified locally

- `npm run build`: 85 HTML pages built
- Root `/index.html` meta-refresh → `/claude-code-marketplace/en/`
- Stylesheet, JS, OG image, internal nav all resolve to `/claude-code-marketplace/...`
- Canonical URL = `https://netresearch.github.io/claude-code-marketplace/en/skills/<slug>/` (project prefix appears exactly once)
- Sitemap 82 URLs all correctly prefixed
- `npm run check:hreflang`: 83 pages scanned, 0 pair gaps, 0 link issues
- `npm run check:orphans`: 40/40 still blocking-clean