### PR TITLE
fix(pages): stash raw README + re-parse on 304 to break stale-cache loop

### DIFF
--- a/site/scripts/fetch-readmes.js
+++ b/site/scripts/fetch-readmes.js
@@ -124,13 +124,12 @@ for (const plugin of marketplace.plugins) {
           dirty = true;
         }
       }
-      if (
-        latestRelease &&
-        JSON.stringify(latestRelease) !== JSON.stringify(existing.latestRelease)
-      ) {
-        existing.latestRelease = latestRelease;
-        dirty = true;
-      } else if (!("latestRelease" in existing)) {
+      // Compare on the canonical-null form so deletions / unpublished releases
+      // also write back (`null` !== `{tag: …}`). Also covers the legacy case
+      // where the cache predates `latestRelease` and has no key at all.
+      const existingRelease =
+        "latestRelease" in existing ? existing.latestRelease : undefined;
+      if (JSON.stringify(latestRelease) !== JSON.stringify(existingRelease ?? null)) {
         existing.latestRelease = latestRelease;
         dirty = true;
       }

--- a/site/scripts/fetch-readmes.js
+++ b/site/scripts/fetch-readmes.js
@@ -63,7 +63,12 @@ for (const plugin of marketplace.plugins) {
 
   try {
     const headers = {};
-    if (existing?.etag) headers["if-none-match"] = existing.etag;
+    // Only use the cached ETag when the cache entry actually has the raw
+    // markdown stashed (post-v6 schema). Older caches would force a 304
+    // and we'd be stuck with whatever parsed shape they captured.
+    if (existing?.etag && typeof existing.raw === "string") {
+      headers["if-none-match"] = existing.etag;
+    }
 
     const res = await octokit.repos.getReadme({ owner, repo, headers });
 
@@ -83,6 +88,7 @@ for (const plugin of marketplace.plugins) {
           repo,
           etag: res.headers.etag || null,
           fetchedAt: new Date().toISOString(),
+          raw,
           parsed,
           latestRelease,
         },
@@ -94,21 +100,41 @@ for (const plugin of marketplace.plugins) {
     process.stdout.write(`  ✓ ${plugin.name}${latestRelease ? ` (${latestRelease.tag})` : ""}\n`);
   } catch (err) {
     if (err.status === 304 && existing) {
-      // README unchanged, but the latest-release pointer drifts independently
-      // and old caches (pre-v5 fetch-readmes) may lack it entirely. Refresh
-      // the release field on every run so visual + JSON-LD snapshots stay
-      // current even on a cache hit.
+      // README content is unchanged upstream, but two things drift
+      // independently of the README's ETag:
+      //
+      //   1. The latest-release pointer (separate API).
+      //   2. The parser logic in `parse-readme.js`. A cache from an older
+      //      parser version would otherwise survive forever because the
+      //      ETag still matches; we'd ship stale parsed sections (this
+      //      bit the live deploy of #44/#46 — `### Marketplace
+      //      (Recommended)` leaked into context-requirements for skills
+      //      whose README had not changed since the parser fix).
+      //
+      // Mitigation: store the raw markdown in the cache and re-run
+      // `parseReadme` against it on every 304 so the latest parser
+      // logic always wins. Old caches (no `raw` field) fall back to
+      // the already-parsed sections.
       const latestRelease = await fetchLatestRelease(owner, repo);
+      let dirty = false;
+      if (typeof existing.raw === "string") {
+        const reparsed = parseReadme(existing.raw);
+        if (JSON.stringify(reparsed) !== JSON.stringify(existing.parsed)) {
+          existing.parsed = reparsed;
+          dirty = true;
+        }
+      }
       if (
         latestRelease &&
         JSON.stringify(latestRelease) !== JSON.stringify(existing.latestRelease)
       ) {
         existing.latestRelease = latestRelease;
-        writeFileSync(cachePath, JSON.stringify(existing, null, 2));
+        dirty = true;
       } else if (!("latestRelease" in existing)) {
         existing.latestRelease = latestRelease;
-        writeFileSync(cachePath, JSON.stringify(existing, null, 2));
+        dirty = true;
       }
+      if (dirty) writeFileSync(cachePath, JSON.stringify(existing, null, 2));
       cached++;
       process.stdout.write(
         `  · ${plugin.name} (not modified${latestRelease ? `, ${latestRelease.tag}` : ""})\n`


### PR DESCRIPTION
## Problem reported on live deploy

https://netresearch.github.io/claude-code-marketplace/en/skills/typo3-testing/ still renders `### Marketplace (Recommended)` verbatim under "What it expects in your project" even though [#46](https://github.com/netresearch/claude-code-marketplace/pull/46) fixed the parser to drop captured headings. Stale data is sticky.

## Cause

The CI cache for `typo3-testing` was written **before** the #46 parser-hygiene fix landed. On every subsequent CI run the upstream README returned an ETag-304, `fetch-readmes.js` kept the cached `parsed` sections verbatim, and the new parser never ran against the unchanged markdown. Cache key changes only force a fresh fetch when the cache is fully missed — `restore-keys: skills-readme-` prefix matches and brings back the stale entry.

So any skill whose README didn't change between the bad parser and now is permanently serving stale parsed sections. That's about half the catalog.

## Fix (two layers)

**1. Cache the raw markdown** alongside `parsed`, `etag`, and `latestRelease`. On every 304 response, re-run `parseReadme(raw)` against the cached source; if the new shape differs, write it back. The parser version effectively becomes part of the freshness contract, not just the README ETag.

**2. Self-heal pre-v6 caches** that don't have the `raw` field yet by suppressing the `If-None-Match` header for them. The next fetch is forced to a 200, brings down fresh markdown, and writes the new schema. After one CI run with this code every cache entry has `raw` and the v6 path takes over.

## Verified locally

- Stripped the `raw` field from `cache/skills-readme/typo3-testing.json` (simulating an old CI cache)
- Re-ran `npm run fetch:readmes`: got a fresh 200, `raw` populated, `parsed.contextRequirements` no longer leaks `### Marketplace (Recommended)`
- Rendered HTML now shows the (locally fixed) bullet as a markdown link: `<li>Add the <a href="…" rel="noopener">Netresearch marketplace</a> once, then browse and install skills:</li>`
- `npm run build`: still 89 files
- `npm run test:visual`: 5/5 baselines pass (typo3-testing not in the snapshot set)

After this PR merges and the workflow runs once, every skill's cache will carry `raw` and any future parser changes will replay automatically on 304.

Refs: live regression report on the typo3-testing detail page