### PR TITLE
feat: add anticipating-shadow-points (ASP) — workflow category

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -366,6 +366,15 @@
         "repo": "netresearch/retro-skill"
       },
       "category": "productivity"
+    },
+    {
+      "name": "anticipating-shadow-points",
+      "description": "Planning protocol: Klein pre-mortem, Berkeley MAST 14-mode failure detection, independent validator subagent, contractual TaskCreate micro-TODO, the goal subprocess execution kernel, per-deliverable sign-off for non-trivial engineering tasks. 12 Iron Laws. Multilingual (EN/ES/PT/IT/HE).",
+      "source": {
+        "source": "github",
+        "repo": "ulissesflores/anticipating-shadow-points"
+      },
+      "category": "workflow"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |
 | markdown-to-pdf | [markdown-to-pdf-skill](https://github.com/netresearch/markdown-to-pdf-skill) | Convert Markdown files to styled PDFs via WeasyPrint; CSS-overridable for branded output |
 | typo3-upgrade-effort-model | [typo3-upgrade-effort-model-skill](https://github.com/netresearch/typo3-upgrade-effort-model-skill) | TYPO3 LTS upgrade effort model: risk multipliers, baselines, version compatibility, Rector coverage, 7-phase workflow |
+| anticipating-shadow-points | [anticipating-shadow-points](https://github.com/ulissesflores/anticipating-shadow-points) | Planning protocol: Klein pre-mortem, Berkeley MAST 14-mode failure detection, independent validator subagent, contractual TaskCreate micro-TODO, the goal subprocess execution kernel, per-deliverable sign-off for non-trivial engineering tasks. 12 Iron Laws. Multilingual (EN/ES/PT/IT/HE). |
 
 ### Brand & visual identity
 


### PR DESCRIPTION
## Summary

Adds the **anticipating-shadow-points** (ASP) plugin to the marketplace catalog under **workflow** category. This is the first non-netresearch community contribution, demonstrating the marketplace's open-standard reach.

## What ASP is

A Claude Code skill that orchestrates a 13-phase protocol for non-trivial engineering tasks. Combines academic-grade methodology with empirically-validated tooling:

- **Klein pre-mortem (1998)** — prospective hindsight for risk identification
- **Berkeley MAST 14-mode failure taxonomy** ([arxiv 2503.13657](https://arxiv.org/abs/2503.13657)) — forced categorization beyond free-form pre-mortem
- **Plan-and-Act separation** ([arxiv 2503.09572](https://arxiv.org/abs/2503.09572))
- **Independent validator subagent** with strict prompt isolation (Reflexion + EMNLP 2025 self-critique limits — separate prompt mandatory)
- **Contractual `TaskCreate` micro-TODO** with PRE/ACT/POST/ACCEPTANCE/FALSIFICATION fields
- **`claude -p /goal` subprocess execution kernel** (Anthropic, 2026-05-12) — worker/evaluator separation via the official primitive
- **12 Iron Laws** enforcing the discipline at every checkpoint

Empirical validation (2026-05-17) surfaced a non-obvious finding that became **Iron Law 11**: `claude -p` returns exit 0 even when the agent gracefully refuses a goal. Routing decisions MUST parse `is_error`, `terminal_reason`, `stop_reason` from the JSON output — `$?` is not reliable for semantic success/failure. This is a community-relevant gotcha worth documenting independently of ASP.

## Quality bar

| Check | Result |
|---|---|
| `scripts/validate.sh` | ✓ all checks PASS (41 plugins) |
| Description length | 274 chars (under 300-char snippet target) |
| Category | `workflow` (within canonical enum) |
| README catalog row | added under "Productivity & Integration" |
| Slug | well-formed, kebab-case |
| Repo MIT-licensed | Yes |
| Plugin manifest (`.claude-plugin/plugin.json`) at source repo | Yes (v0.2.0) |
| Self-host marketplace (`.claude-plugin/marketplace.json` in repo) | Yes |
| Plugin install empirically tested | Yes — `claude plugin install` succeeded; skill loads as expected |
| Multilingual docs | EN (native) + ES/PT/IT/HE (machine-assisted with PR invitation for native review) |
| Full SOTA design doc | [docs/ARCHITECTURE.md](https://github.com/ulissesflores/anticipating-shadow-points/blob/main/docs/ARCHITECTURE.md) |

## Test plan

- [x] `scripts/validate.sh` passes locally on fork branch
- [x] Plugin tested end-to-end: `claude plugin marketplace add ulissesflores/anticipating-shadow-points` + `claude plugin install` succeeds; uninstall/reinstall clean
- [x] `claude --plugin-dir` smoke test confirms all four invocation aliases register
- [x] Source repo has v0.2.0 release with proper plugin format (`.claude-plugin/plugin.json` + restructured `skills/` and `commands/` directories)
- [ ] Reviewer can run `bash scripts/validate.sh` to confirm marketplace integrity

## Notes

- This is the **first non-netresearch** entry in the catalog. Happy to follow any maintainer feedback on positioning, description tweaks, or category reassignment.
- Source repo: https://github.com/ulissesflores/anticipating-shadow-points (MIT, v0.2.0)
- Author: Ulisses Flores (@ulissesflores)
- License compatibility: MIT (matches marketplace policy)

Thank you for maintaining this catalog — the validate.sh quality gate is exemplary and made integration straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)