### PR TITLE
add authsome to security

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,15 @@
   },
   "plugins": [
     {
+      "name": "authsome",
+      "description": "Local credential broker for AI agents. Log in once via OAuth2 or API key. Credentials sit in an encrypted local vault and a local proxy injects them at request time so agents never see raw secrets. 45 providers bundled.",
+      "source": {
+        "source": "github",
+        "repo": "agentrhq/authsome"
+      },
+      "category": "security"
+    },
+    {
       "name": "enterprise-readiness",
       "description": "Assess and enhance software projects for enterprise-grade security, quality, and automation. Includes supply chain security (SLSA, signing, SBOMs), quality gates, and platform-specific hardening with dynamic scoring.",
       "source": {


### PR DESCRIPTION
hey, opening this to add authsome under the security category.

authsome is a local credential broker for AI agents. log in once via OAuth2 or API key, vault stores secrets locally, a local proxy injects them at request time so agents never touch raw values. 45 providers bundled (14 OAuth2, 31 API key).

one thing worth flagging: agentrhq/authsome ships its own `.claude-plugin/marketplace.json` at the repo root which then points at `skills/authsome/`. so the github source reference in this PR resolves through that indirection rather than a flat repo-root SKILL.md like your existing entries (e.g. netresearch/enterprise-readiness-skill). if your loader doesn't follow that indirection, i can ship a standalone `agentrhq/authsome-skill` repo with SKILL.md at root and re-point the source.

happy to reword anything in the entry.

upstream repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
