### PR TITLE
feat: add Longbridge Securities financial market skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -366,6 +366,15 @@
         "repo": "netresearch/retro-skill"
       },
       "category": "productivity"
+    },
+    {
+      "name": "longbridge",
+      "description": "Agent skills for Longbridge Securities — real-time quotes, charts, fundamentals, portfolio analytics for HK/US/A-share/SG markets. 125+ skills covering prices, earnings, options, watchlist, sector screening, and more. Trilingual (ZH-Hans/ZH-Hant/EN).",
+      "source": {
+        "source": "github",
+        "repo": "longbridge/skills"
+      },
+      "category": "finance"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 |-------|-----------|-------------|
 | netresearch-branding | [netresearch-branding-skill](https://github.com/netresearch/netresearch-branding-skill) | Netresearch brand guidelines: colors, typography, components |
 
+### Finance & Trading
+
+| Skill | Repository | Description |
+|-------|-----------|-------------|
+| longbridge | [longbridge/skills](https://github.com/longbridge/skills) | Agent skills for Longbridge Securities — real-time quotes, charts, fundamentals, portfolio analytics for HK/US/A-share/SG. 125+ skills, trilingual (ZH-Hans/ZH-Hant/EN) |
+
 ## Architecture
 
 This marketplace uses **source references** — it contains only a `marketplace.json` catalog that points to individual skill repositories. Claude Code fetches skills directly from their source repos when installed.


### PR DESCRIPTION
## Summary

- Adds a new **Finance & Trading** section to `README.md` with an entry for [longbridge/skills](https://github.com/longbridge/skills)
- Adds a corresponding `longbridge` plugin entry to `.claude-plugin/marketplace.json` (category: `finance`)

## About the skill pack

[Longbridge Securities](https://longbridge.com) is a major HK/SG-licensed broker. Their Agent Skills pack provides:

- **125+ skills** covering real-time quotes, candlestick charts, fundamentals, options chains, portfolio analytics, sector screening, earnings analysis, watchlist management, and more
- **Markets**: HK, US, A-share (SH/SZ), Singapore
- **Trilingual triggers**: Simplified Chinese / Traditional Chinese / English (e.g. `股价`/`股價`/`stock price`, `盘口`/`盤口`/`orderbook`)
- **CLI-first**: calls the `longbridge` binary directly; falls back to MCP if not installed

## Installation (after merging)

```bash
/plugin marketplace add netresearch/claude-code-marketplace
# then browse to longbridge
```

Or directly:

```bash
/plugin marketplace add longbridge/skills
```

## Test plan

- [ ] Verify `marketplace.json` is valid JSON after the change
- [ ] Confirm the `longbridge/skills` GitHub repo is publicly accessible
- [ ] Install via `claude plugin marketplace add longbridge/skills` and confirm skills load

🤖 Generated with [Claude Code](https://claude.com/claude-code)