### PR TITLE
feat: register typo3-site-conformance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | Skill | Repository | Description |
 |-------|-----------|-------------|
 | typo3-conformance | [typo3-conformance-skill](https://github.com/netresearch/typo3-conformance-skill) | Evaluate TYPO3 extension quality and standards compliance |
-| typo3-site-conformance | [typo3-site-conformance-skill](https://github.com/netresearch/typo3-site-conformance-skill) | Conformance for deployable TYPO3 site/project repos (containers, CI, supply-chain, secrets) |
+| typo3-site-conformance | [typo3-site-conformance-skill](https://github.com/netresearch/typo3-site-conformance-skill) | Conformance for deployable TYPO3 site/project repos (containers / CI / supply-chain / secrets) |
 | typo3-testing | [typo3-testing-skill](https://github.com/netresearch/typo3-testing-skill) | Test infrastructure: unit, functional, E2E, architecture, mutation |
 | typo3-docs | [typo3-docs-skill](https://github.com/netresearch/typo3-docs-skill) | Create and maintain TYPO3 extension documentation for docs.typo3.org |
 | typo3-ddev | [typo3-ddev-skill](https://github.com/netresearch/typo3-ddev-skill) | DDEV environment setup for TYPO3 extension development |


### PR DESCRIPTION
Registers the new [`typo3-site-conformance`](https://github.com/netresearch/typo3-site-conformance-skill) plugin.

It is the **site/project** counterpart to `typo3-conformance` (which is extension-scoped): conformance + hardening for deployable TYPO3 v14 repos (`type: project` + Docker/Compose) — repository layout, container/Compose topology, Concourse CI, supply-chain gating, secret handling, and the Valkey/ofelia runtime. The 73-rule catalogue is single-sourced (the skill routes to the [gold-standard spec](https://pages.nrdev.de/typo3/typo3-project-standard) and the executable checker in [`typo3-14-gold`](https://git.netresearch.de/typo3/typo3-14-gold)); the skill carries methodology + routing only.

- New repo CI (Lint + CodeQL): green.
- Marketplace validator: 41 plugins, valid; description 274 chars; README catalog row added.

Closes the extension-vs-site discoverability gap surfaced while building the gold TYPO3 v14 reference project.