### PR TITLE
ci: bump actions/cache from v4.3.0 to v5.0.5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci
 
       - name: Restore README cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: site/cache/skills-readme
           key: skills-readme-${{ hashFiles('.claude-plugin/marketplace.json', 'site/scripts/fetch-readmes.js', 'site/scripts/parse-readme.js') }}
@@ -89,7 +89,7 @@ jobs:
         run: npm ci
 
       - name: Restore README cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: site/cache/skills-readme
           key: skills-readme-${{ hashFiles('.claude-plugin/marketplace.json', 'site/scripts/fetch-readmes.js', 'site/scripts/parse-readme.js') }}
@@ -147,7 +147,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Restore README cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: site/cache/skills-readme
           key: skills-readme-${{ hashFiles('.claude-plugin/marketplace.json', 'site/scripts/fetch-readmes.js', 'site/scripts/parse-readme.js') }}


### PR DESCRIPTION
Bumps the `actions/cache` SHA pin in all three jobs of `pages.yml` from [v4.3.0](https://github.com/actions/cache/releases/tag/v4.3.0) to [v5.0.5](https://github.com/actions/cache/releases/tag/v5.0.5) (`27d5ce7f107fe9357f9df03efb73ab90386fccae`, verified via the tags API).

The v4 line runs on Node.js 20, flagged as deprecated in the [latest main deploy run](https://github.com/netresearch/claude-code-marketplace/actions/runs/27256429235): GitHub forces Node 24 from **2026-06-16** and removes Node 20 from runners on 2026-09-16. v5 runs on Node 24 natively; the cache key/path interface is unchanged.