### PR TITLE
docs: bring AGENTS.md to agent-rules conformance with scoped files

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,61 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-06-10 -->
+
+# AGENTS.md — .github/workflows/
+
+## Overview
+
+CI for the marketplace: catalog validation, security scanning, and the Pages
+build/deploy pipeline. Root [AGENTS.md](../../AGENTS.md) applies on top.
+
+## Workflow files
+
+| File | Purpose |
+|------|---------|
+| `pages.yml` | Pages pipeline: build → compliance checks → Lighthouse → visual regression → deploy (push to main, PRs, weekly cron, dispatch) |
+| `validate.yml` | Marketplace catalog validation (`scripts/validate.sh`) |
+| `security.yml` | Secret scanning (gitleaks/betterleaks), dependency review |
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Lint workflows locally | `actionlint .github/workflows/*.yml` |
+| Check run annotations | `gh api repos/netresearch/claude-code-marketplace/commits/SHA/check-runs --jq '.check_runs[] | select(.output.annotations_count > 0)'` |
+
+## Workflow conventions
+
+- Minimal `permissions:` per job; never `permissions: write-all`.
+- Job IDs kebab-case, step names sentence case.
+- The deploy job runs only on push to `main`; PR runs build and gates only.
+
+## Security
+
+- **Pin third-party actions by full commit SHA** with a `# vX.Y.Z` comment.
+  Verify the latest release via the API before pinning
+  (`gh api repos/OWNER/ACTION/releases/latest`) — never copy SHAs from memory
+  or other files.
+- First-party `netresearch/*` reusable workflows are referenced `@main`,
+  never SHA-pinned.
+- Never `secrets: inherit` when calling reusable workflows — pass each secret
+  explicitly by name.
+
+## Examples
+
+- Good: `uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`
+- Bad: `uses: actions/cache@v5` (mutable tag, supply-chain risk)
+- Bad: `uses: netresearch/some-workflow@<sha>` (first-party is `@main`)
+
+## Checklist (before PR)
+
+1. `actionlint` clean on changed files.
+2. New/updated third-party actions: latest version confirmed via API, SHA
+   valid, `# vX.Y.Z` comment matches.
+3. Quality gates stay blocking — never add `continue-on-error` to get green.
+4. Workflow-file PRs cannot be auto-merged by bots (`GITHUB_TOKEN` lacks the
+   `workflows` scope) — plan a manual merge.
+
+## When stuck
+
+- Site build steps mirror local commands: [../../site/AGENTS.md](../../site/AGENTS.md).
+- Marketplace validation rules: [../../AGENTS.md](../../AGENTS.md).
+- Check the job's Annotations tab — runs can pass while emitting warnings.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -13,14 +13,14 @@ build/deploy pipeline. Root [AGENTS.md](../../AGENTS.md) applies on top.
 |------|---------|
 | `pages.yml` | Pages pipeline: build → compliance checks → Lighthouse → visual regression → deploy (push to main, PRs, weekly cron, dispatch) |
 | `validate.yml` | Marketplace catalog validation (`scripts/validate.sh`) |
-| `security.yml` | Secret scanning (gitleaks/betterleaks), dependency review |
+| `security.yml` | gitleaks secret scanning + dependency review (via `netresearch/.github` reusable workflows); the separate `betterleaks` check comes from GitHub Advanced Security, not this file |
 
 ## Commands
 
 | Task | Command |
 |------|---------|
 | Lint workflows locally | `actionlint .github/workflows/*.yml` |
-| Check run annotations | `gh api repos/netresearch/claude-code-marketplace/commits/SHA/check-runs --jq '.check_runs[] | select(.output.annotations_count > 0)'` |
+| Check run annotations | `gh api repos/netresearch/claude-code-marketplace/commits/<SHA>/check-runs --jq '.check_runs[] | select(.output.annotations_count > 0)'` |
 
 ## Workflow conventions
 

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/GEMINI.md
+++ b/.github/workflows/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Rules for coding agents editing **`netresearch/claude-code-marketplace`**.  
 They apply to marketplace maintenance only: catalog, landing pages, SEO presentation, cross-linking, and aggregation.
 
-**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. This root file holds marketplace-wide policy; see the [scope index](#index-of-scoped-agentsmd) below.
+**Precedence:** rules are additive — scoped files extend this root policy, and on conflict the **closest `AGENTS.md`** to the files you're changing wins. See the [scope index](#index-of-scoped-agentsmd) below.
 
 **Do not copy skill-repository quality rules here.** Those live in [`netresearch/skill-repo-skill`](https://github.com/netresearch/skill-repo-skill) (skill-repo skill). **Do not duplicate runtime instructions from individual `SKILL.md` files** — the marketplace describes *how skills are found and presented*, not how they execute.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,21 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-06-10 -->
+
 # AGENTS.md — Netresearch Claude Code Marketplace
 
 Rules for coding agents editing **`netresearch/claude-code-marketplace`**.  
 They apply to marketplace maintenance only: catalog, landing pages, SEO presentation, cross-linking, and aggregation.
 
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. This root file holds marketplace-wide policy; see the [scope index](#index-of-scoped-agentsmd) below.
+
 **Do not copy skill-repository quality rules here.** Those live in [`netresearch/skill-repo-skill`](https://github.com/netresearch/skill-repo-skill) (skill-repo skill). **Do not duplicate runtime instructions from individual `SKILL.md` files** — the marketplace describes *how skills are found and presented*, not how they execute.
+
+---
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Validate marketplace.json + README catalog | `./scripts/validate.sh` |
 
 ---
 
@@ -129,3 +141,10 @@ Before completing a marketplace PR:
 
 - Skill repository structure and validation: **`netresearch/skill-repo-skill`**
 - Do **not** move runtime behavior documentation into this marketplace; link to source repos instead.
+
+## Index of scoped AGENTS.md
+
+| Directory | Read first when touching |
+|---|---|
+| [site/AGENTS.md](./site/AGENTS.md) | Eleventy Pages site: templates, data pipeline, checks |
+| [.github/workflows/AGENTS.md](./.github/workflows/AGENTS.md) | CI workflows: pages, validate, security |

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,78 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-06-10 -->
+
+# AGENTS.md — site/ (Eleventy Pages site)
+
+## Overview
+
+Bilingual (EN/DE) Eleventy 3.x source for the GitHub Pages discovery site.
+Root [AGENTS.md](../AGENTS.md) policy (categories, SEO copy rules, no-orphan
+rule, mirroring rule) applies on top. Operational details: [README.md](README.md).
+Design rationale: [../docs/decisions/](../docs/decisions/).
+
+Data flow (do not bypass): `../.claude-plugin/marketplace.json` →
+`src/_data/marketplace.js` → merged with fetched skill-repo READMEs
+(`scripts/fetch-readmes.js` + `parse-readme.js`, ETag-cached) →
+`src/_data/skills.js` → templates.
+
+## Setup
+
+```bash
+cd site && npm install
+export GITHUB_TOKEN=$(gh auth token)   # needed for fetch:readmes
+```
+
+## Commands (run from `site/`)
+
+| Task | Command |
+|------|---------|
+| Full CI-equivalent build | `npm run build:all` |
+| Fast build vs. cache | `npm run build` |
+| Dev server | `npm run dev` |
+| Compliance checks | `npm run check` (categories, orphans, SEO) |
+| Hreflang pairs (post-build) | `npm run check:hreflang` |
+| Visual regression | `npm run test:visual` (`:update` to refresh baselines) |
+
+## Conventions
+
+- Templates: Nunjucks, semantic HTML5, one `<h1>` per page, BEM-light classes.
+- CSS: tokens in `assets/css/tokens.css`, layout in `main.css`, no `!important`.
+- JS: vanilla ES2022 progressive enhancement only (~5 KB budget, `defer`);
+  every page must work without JavaScript.
+- German copy is authored independently in German technical register — never
+  a translation echo of the English text (`descriptions_de.json`, `i18n/de.json`).
+- Every EN page needs its DE counterpart and vice versa — `check:hreflang`
+  breaks the build on missing pairs.
+- Commits: `feat(pages):` / `fix(site):` style scopes, DCO sign-off, signed.
+
+## Security
+
+- No third-party scripts, analytics, external fonts, or cookies
+  ([ADR-0003](../docs/decisions/0003-no-client-side-analytics.md)).
+- Never commit tokens; `GITHUB_TOKEN` is read from the environment only.
+- README-derived content is parsed, not executed; keep the parser's URL
+  handling restrictive (allowlist) when extending it.
+
+## Examples
+
+- Good: skill card data read from `skills.js` collection in the template.
+- Bad: hardcoding a skill name, description, or URL in a `.njk` template —
+  data must flow from `marketplace.json` + fetched READMEs.
+- Good: new UI string added to both `i18n/en.json` and `i18n/de.json`.
+- Bad: English fallback text inline in a template.
+
+## Checklist (before PR)
+
+1. `npm run check` green (categories, orphans; SEO warnings reviewed).
+2. `npm run build` + `npm run check:hreflang` green.
+3. `npm run test:visual` — update baselines only for intended UI changes,
+   inspect the diff first.
+4. `src/assets/og/` not staged (generated, gitignored).
+5. Quality gates stay blocking — never weaken Lighthouse thresholds
+   (Perf/BP ≥ 0.95, A11y = 1.0, SEO = 1.0).
+
+## When stuck
+
+- Build/commands: [README.md](README.md); CI behavior:
+  [../.github/workflows/pages.yml](../.github/workflows/pages.yml).
+- Why it is built this way: [../docs/decisions/](../docs/decisions/).
+- Marketplace policy (categories, SEO rules): [../AGENTS.md](../AGENTS.md).

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -18,7 +18,7 @@ Data flow (do not bypass): `../.claude-plugin/marketplace.json` →
 
 ```bash
 cd site && npm install
-export GITHUB_TOKEN=$(gh auth token)   # needed for fetch:readmes
+export GITHUB_TOKEN=$(gh auth token)   # optional for fetch:readmes; avoids the 60-req/h anonymous rate limit
 ```
 
 ## Commands (run from `site/`)
@@ -30,7 +30,8 @@ export GITHUB_TOKEN=$(gh auth token)   # needed for fetch:readmes
 | Dev server | `npm run dev` |
 | Compliance checks | `npm run check` (categories, orphans, SEO) |
 | Hreflang pairs (post-build) | `npm run check:hreflang` |
-| Visual regression | `npm run test:visual` (`:update` to refresh baselines) |
+| Visual regression | `npm run test:visual` |
+| Refresh visual baselines | `npm run test:visual:update` |
 
 ## Conventions
 
@@ -64,8 +65,8 @@ export GITHUB_TOKEN=$(gh auth token)   # needed for fetch:readmes
 
 1. `npm run check` green (categories, orphans; SEO warnings reviewed).
 2. `npm run build` + `npm run check:hreflang` green.
-3. `npm run test:visual` — update baselines only for intended UI changes,
-   inspect the diff first.
+3. `npm run test:visual` green — for intended UI changes, refresh baselines
+   with `npm run test:visual:update` after inspecting the diff.
 4. `src/assets/og/` not staged (generated, gitignored).
 5. Quality gates stay blocking — never weaken Lighthouse thresholds
    (Perf/BP ≥ 0.95, A11y = 1.0, SEO = 1.0).

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/site/GEMINI.md
+++ b/site/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Fixes all findings from the agent-rules skill validator (follow-up to #66, where the symlink fix already landed):

- **Root `AGENTS.md`** (policy content untouched, structural additions only): managed header with last-updated date, precedence statement, verifiable Commands section (`./scripts/validate.sh`), and an Index of scoped AGENTS.md. 150 lines.
- **`site/AGENTS.md` (new):** scoped rules for the Eleventy site with the full required section structure (Overview, Setup, Commands, Conventions, Security, Examples, Checklist, When stuck) — pointers to `site/README.md` and the ADRs rather than duplication.
- **`.github/workflows/AGENTS.md` (new):** scoped CI rules — SHA-pinning discipline, permissions, secrets handling, blocking-gates policy.
- **Subdirectory `CLAUDE.md`/`GEMINI.md` symlinks** for both scoped dirs (without them, scoped AGENTS.md files are never auto-loaded by Claude Code).

### Assessment results

| Check | Before | After |
|---|---|---|
| validate-structure | 2 errors, 1 warning | **0 errors, 0 warnings** |
| check-freshness | unknown (no date) | all 3 fresh |
| verify-content / verify-commands | n/a | all pass |
| Quality score | C 60/100 | **root A 90/100, scoped 2× 100/100, avg 97/100** |

Root conciseness stays 10/20 deliberately: the 50-line thin-root target would require gutting the hand-curated marketplace policy canon, which is not worth the trade.