### PR TITLE
Add 7 community creative/visual tooling plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,6 +375,69 @@
         "repo": "netresearch/retro-skill"
       },
       "category": "productivity"
+    },
+    {
+      "name": "lookdev",
+      "description": "Human-in-the-loop web studio to tune AI-generated output by eye.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/lookdev-studio-skill"
+      },
+      "category": "design"
+    },
+    {
+      "name": "deterministic-design",
+      "description": "Render the UI and prove it's balanced + usable: deterministic layout audit + vision-judged usability.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/deterministic-design-skill"
+      },
+      "category": "design"
+    },
+    {
+      "name": "ckw-design",
+      "description": "Frontend design skill: direction, design system, visual philosophy.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/ckw-design-skill"
+      },
+      "category": "design"
+    },
+    {
+      "name": "screenstudio-alt",
+      "description": "Open-source headless Screen Studio alternative: auto-zoom, idle speed-up, vertical export.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/screenstudio-alternative-skill"
+      },
+      "category": "productivity"
+    },
+    {
+      "name": "web-media-getter",
+      "description": "One query across free image/video/GIF APIs, license-tagged results.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/web-media-getter-skill"
+      },
+      "category": "productivity"
+    },
+    {
+      "name": "macos-screen-recorder",
+      "description": "macOS screen recorder with system audio via ScreenCaptureKit, CLI, no driver.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/macos-screen-recorder-system-audio"
+      },
+      "category": "productivity"
+    },
+    {
+      "name": "lookdev-auto",
+      "description": "Automated visual tuning: a vision model rates rendered variants in a loop.",
+      "source": {
+        "source": "github",
+        "repo": "connerkward/lookdev-auto-skill"
+      },
+      "category": "design"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > **You ship code. Your agent should know your stack.**
 
-40 curated Agent Skills for TYPO3, PHP, Go, Docker, Jira, security, and documentation — portable across Claude Code, Cursor, Copilot, Codex, Gemini CLI, and 30+ other agents.
+48 curated Agent Skills for TYPO3, PHP, Go, Docker, Jira, security, and documentation — portable across Claude Code, Cursor, Copilot, Codex, Gemini CLI, and 30+ other agents.
 
 [![Marketplace site](https://img.shields.io/badge/marketplace-netresearch.github.io-2F99A4)](https://netresearch.github.io/claude-code-marketplace/)
-[![Skills](https://img.shields.io/badge/skills-40-2F99A4)](https://netresearch.github.io/claude-code-marketplace/en/skills/)
+[![Skills](https://img.shields.io/badge/skills-48-2F99A4)](https://netresearch.github.io/claude-code-marketplace/en/skills/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/netresearch/claude-code-marketplace/badge)](https://scorecard.dev/viewer/?uri=github.com/netresearch/claude-code-marketplace)
 
@@ -125,6 +125,20 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | Skill | Repository | Description |
 |-------|-----------|-------------|
 | netresearch-branding | [netresearch-branding-skill](https://github.com/netresearch/netresearch-branding-skill) | Netresearch brand guidelines: colors, typography, components |
+
+### Creative & visual tooling (community)
+
+External community-contributed skills for visual tuning, design review, and screen/media capture. Maintained outside Netresearch under [github.com/connerkward](https://github.com/connerkward).
+
+| Skill | Repository | Description |
+|-------|-----------|-------------|
+| lookdev | [lookdev-studio-skill](https://github.com/connerkward/lookdev-studio-skill) | Human-in-the-loop web studio to tune AI-generated output by eye |
+| lookdev-auto | [lookdev-auto-skill](https://github.com/connerkward/lookdev-auto-skill) | Automated visual tuning: a vision model rates rendered variants in a loop |
+| deterministic-design | [deterministic-design-skill](https://github.com/connerkward/deterministic-design-skill) | Deterministic layout audit + vision-judged usability for rendered UIs |
+| ckw-design | [ckw-design-skill](https://github.com/connerkward/ckw-design-skill) | Frontend design skill: direction, design system, visual philosophy |
+| screenstudio-alt | [screenstudio-alternative-skill](https://github.com/connerkward/screenstudio-alternative-skill) | Open-source headless Screen Studio alternative: auto-zoom, idle speed-up, vertical export |
+| web-media-getter | [web-media-getter-skill](https://github.com/connerkward/web-media-getter-skill) | One query across free image/video/GIF APIs, license-tagged results |
+| macos-screen-recorder | [macos-screen-recorder-system-audio](https://github.com/connerkward/macos-screen-recorder-system-audio) | macOS screen recorder with system audio via ScreenCaptureKit, CLI, no driver |
 
 ## Architecture
 

--- a/site/src/_data/groups.js
+++ b/site/src/_data/groups.js
@@ -20,6 +20,7 @@ export default {
     "devops",
     "productivity",
     "brand",
+    "creative-media",
   ],
   groups: {
     "skill-skills": {
@@ -105,6 +106,25 @@ export default {
       en: { title: "Brand & visual identity", lead: "Visual conventions for Netresearch artifacts." },
       de: { title: "Brand & visuelle Identität", lead: "Visuelle Konventionen für Netresearch-Artefakte." },
       slugs: ["netresearch-branding"],
+    },
+    "creative-media": {
+      en: {
+        title: "Creative & visual tooling (community)",
+        lead: "External community-contributed skills for visual tuning, design review, and screen/media capture.",
+      },
+      de: {
+        title: "Kreativ- & Visual-Tooling (Community)",
+        lead: "Externe Community-Skills für visuelles Tuning, Design-Review und Screen-/Media-Aufnahme.",
+      },
+      slugs: [
+        "lookdev",
+        "lookdev-auto",
+        "deterministic-design",
+        "ckw-design",
+        "screenstudio-alt",
+        "web-media-getter",
+        "macos-screen-recorder",
+      ],
     },
   },
 };


### PR DESCRIPTION
## What this adds

Seven community-maintained Agent Skills focused on visual tuning, design review, and screen/media capture. They live under [github.com/connerkward](https://github.com/connerkward) (MIT, public), so they're external to the Netresearch set — listed here for discovery. Curate or drop any as you see fit; that's your call as maintainer.

| Slug | Repo | Category |
|------|------|----------|
| `lookdev` | `connerkward/lookdev-studio-skill` | design |
| `lookdev-auto` | `connerkward/lookdev-auto-skill` | design |
| `deterministic-design` | `connerkward/deterministic-design-skill` | design |
| `ckw-design` | `connerkward/ckw-design-skill` | design |
| `screenstudio-alt` | `connerkward/screenstudio-alternative-skill` | productivity |
| `web-media-getter` | `connerkward/web-media-getter-skill` | productivity |
| `macos-screen-recorder` | `connerkward/macos-screen-recorder-system-audio` | productivity |

Categories are picked from the canonical enum in `AGENTS.md` / `validate.sh` — there's no `media`/`design-only-visual` bucket, so the eye-tuning and design-system skills go under `design` and the capture/fetch tooling under `productivity`.

## Why the extra files

To keep CI green I also:

- **README catalog** — added a `Creative & visual tooling (community)` section with a row per skill (the validator requires a `| <slug> |` table cell for every plugin), and bumped the count badge + intro to 48.
- **`site/src/_data/groups.js`** — added a matching `creative-media` group. Without it, the no-orphan check (`site/scripts/check-orphans.js`) flags each new skill as having no related skills. Grouping the seven together resolves their related-skills from within the group, so no `overrides.json` entries are needed.

## Validator results (run locally)

- `./scripts/validate.sh` → **green**, 48 plugins, every plugin has a README catalog row, categories within the canonical set, descriptions unique and under the cap.
- `site/` `npm run check` → **green**: `check:categories` 48/48, `check:orphans` 48/48, `check:seo` 48/48.
- `npm run build` → builds, EN+DE detail pages generated for all seven; `check-hreflang.js` → 0 gaps.

## One thing for you

The `visual-regression` job will need its landing snapshots regenerated. The baselines are platform-pinned (`*-chromium-desktop-linux.png`) and I'm on macOS, so I can't produce matching Linux baselines — and the landing now has an extra group section + seven cards + an updated count, which a full-page diff at the 0.5% tolerance won't pass against the old baseline. A `npm run test:visual:update` on the Linux runner (or accepting the diff on merge) handles it. I deliberately did **not** commit macOS-rendered `-darwin` snapshots, since they'd mismatch CI and corrupt the baseline.
