### PR TITLE
Add okf-author — Open Knowledge Format (OKF) authoring & validation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,6 +375,15 @@
         "repo": "netresearch/retro-skill"
       },
       "category": "productivity"
+    },
+    {
+      "name": "okf-author",
+      "description": "Markdown knowledge bases drift without a shared structure, so agents can't reliably parse them. okf-author authors, converts, and validates Markdown in Open Knowledge Format (OKF) — Google's open spec for knowledge as Markdown files with YAML frontmatter — with a dependency-free OKF v0.1 validator.",
+      "source": {
+        "source": "github",
+        "repo": "parkscloud/okf-author"
+      },
+      "category": "document"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |
 | markdown-to-pdf | [markdown-to-pdf-skill](https://github.com/netresearch/markdown-to-pdf-skill) | Convert Markdown files to styled PDFs via WeasyPrint; CSS-overridable for branded output |
+| okf-author | [okf-author](https://github.com/parkscloud/okf-author) | Author, convert, and validate Markdown in Open Knowledge Format (OKF); bundled dependency-free OKF v0.1 conformance validator |
 | typo3-upgrade-effort-model | [typo3-upgrade-effort-model-skill](https://github.com/netresearch/typo3-upgrade-effort-model-skill) | TYPO3 LTS upgrade effort model: risk multipliers, baselines, version compatibility, Rector coverage, 7-phase workflow |
 
 ### Brand & visual identity


### PR DESCRIPTION
Adds **okf-author** to the marketplace (category: `document`).

okf-author is a cross-agent Agent Skill + Claude Code plugin to **author, convert, and validate** Markdown in [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog) — Google Cloud's open v0.1 spec for representing knowledge as a directory of Markdown files with YAML frontmatter.

- **Author** new Markdown as OKF-conformant
- **Convert** existing Markdown into OKF (safe, staged, non-destructive)
- **Validate** a bundle against the OKF v0.1 §9 conformance rules with a bundled, dependency-free checker

Details:
- Repo: https://github.com/parkscloud/okf-author
- License: MIT (the OKF spec is vendored verbatim, Apache-2.0, so the tool tracks the real spec)
- Passes `claude plugin validate --strict` (plugin + marketplace)

Entry appended to the end of `plugins` to match the existing order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
