### PR TITLE
feat: add jujutsu-workflow skill to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -170,6 +170,15 @@
       "category": "development"
     },
     {
+      "name": "jujutsu-workflow",
+      "description": "Stop coding agents losing work and corrupting branch state in git: use Jujutsu (jj) as the local change layer — reversible op-log undo, conflicts-as-data, non-interactive history surgery — while Git stays the canonical remote/PR/CI interface. Proven with evals to beat pure git for agents.",
+      "source": {
+        "source": "github",
+        "repo": "netresearch/jujutsu-workflow-skill"
+      },
+      "category": "development"
+    },
+    {
       "name": "skill-repo",
       "description": "Guide for structuring Netresearch skill repositories with multi-channel distribution. Covers repository standards, composer.json configuration, release workflows, and validation scripts.",
       "source": {

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | git-workflow | [git-workflow-skill](https://github.com/netresearch/git-workflow-skill) | Branching strategies, Conventional Commits, PR workflows |
 | github-project | [github-project-skill](https://github.com/netresearch/github-project-skill) | GitHub repo setup: branch protection, CODEOWNERS, auto-merge |
 | github-release | [github-release-skill](https://github.com/netresearch/github-release-skill) | Safe, automated GitHub releases with supply chain security. Prevents dangerous gh release commands, orchestrates version bumps, signed tags, and CI-driven releases across ecosystems. |
+| jujutsu-workflow | [jujutsu-workflow-skill](https://github.com/netresearch/jujutsu-workflow-skill) | Agent-safe version control with Jujutsu (jj): jj as the local change layer (reversible op-log undo, conflicts-as-data, non-interactive history surgery), Git as the canonical remote/PR/CI interface; proven with evals to beat pure git for agents |
 
 ### Productivity & Integration
 


### PR DESCRIPTION
Registers the new [jujutsu-workflow-skill](https://github.com/netresearch/jujutsu-workflow-skill) in the catalog.

- Adds the `jujutsu-workflow` entry to `.claude-plugin/marketplace.json` (category `development`, alongside git-workflow / github-project) and the matching README catalog row.
- Description is problem-first, names jj + Git, 289 chars (≤300 target).
- Related skills (real adjacencies): git-workflow, github-project.
- Not DACH/TYPO3/Oro-specific → German short description N/A.

`scripts/validate.sh`: **Marketplace valid: 42 plugins** (0 warnings, every plugin has a README catalog row).