### PR TITLE
feat(site): add Aident skill listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -278,6 +278,15 @@
       "category": "workflow"
     },
     {
+      "name": "aident-skill",
+      "description": "Use Aident Loadout to connect your AI agents to 1,000+ real-world apps and tools like Gmail, Slack, Linear, Notion, Firecrawl, and Fal, unlock 27,000+ executable actions, and track full audit history so your agents can get real work done reliably.",
+      "source": {
+        "source": "github",
+        "repo": "Aident-AI/aident-skill"
+      },
+      "category": "workflow"
+    },
+    {
       "name": "typo3-typoscript-ref",
       "description": "Version-aware TypoScript, TSconfig and Fluid reference lookup with always-on best practices. Keyword search across cached documentation, 14 ready-to-use recipes, code review checklists, deprecation checks, migration guides, debugging reference. Supports TYPO3 v12, v13, and v14.",
       "source": {

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > **You ship code. Your agent should know your stack.**
 
-40 curated Agent Skills for TYPO3, PHP, Go, Docker, Jira, security, and documentation — portable across Claude Code, Cursor, Copilot, Codex, Gemini CLI, and 30+ other agents.
+43 curated Agent Skills for TYPO3, PHP, Go, Docker, Jira, security, and documentation — portable across Claude Code, Cursor, Copilot, Codex, Gemini CLI, and 30+ other agents.
 
 [![Marketplace site](https://img.shields.io/badge/marketplace-netresearch.github.io-2F99A4)](https://netresearch.github.io/claude-code-marketplace/)
-[![Skills](https://img.shields.io/badge/skills-40-2F99A4)](https://netresearch.github.io/claude-code-marketplace/en/skills/)
+[![Skills](https://img.shields.io/badge/skills-43-2F99A4)](https://netresearch.github.io/claude-code-marketplace/en/skills/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/netresearch/claude-code-marketplace/badge)](https://scorecard.dev/viewer/?uri=github.com/netresearch/claude-code-marketplace)
 
@@ -110,6 +110,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 |-------|-----------|-------------|
 | jira-integration | [jira-skill](https://github.com/netresearch/jira-skill) | Jira API operations and wiki markup (two sub-skills) |
 | matrix-communication | [matrix-skill](https://github.com/netresearch/matrix-skill) | Send messages to Matrix rooms |
+| aident-skill | [aident-skill](https://github.com/Aident-AI/aident-skill) | Use Aident Loadout to connect your AI agents to 1,000+ real-world apps and tools like Gmail, Slack, Linear, Notion, Firecrawl, and Fal, unlock 27,000+ executable actions, and track full audit history so your agents can get real work done reliably. |
 | cli-tools | [cli-tools-skill](https://github.com/netresearch/cli-tools-skill) | Auto-install missing CLI tools (74+ tool catalog) |
 | context7 | [context7-skill](https://github.com/netresearch/context7-skill) | Library documentation lookup via Context7 REST API |
 | data-tools | [data-tools-skill](https://github.com/netresearch/data-tools-skill) | Structured data manipulation with jq, yq, dasel, qsv |

--- a/site/src/_data/descriptions_de.json
+++ b/site/src/_data/descriptions_de.json
@@ -26,6 +26,7 @@
   "github-release": "Sichere automatisierte GitHub-Releases mit Supply-Chain-Security. Verhindert riskante gh-release-Kommandos, orchestriert Version-Bumps, signierte Tags und CI-getriebene Releases.",
   "agent-rules": "Generiert AGENTS.md mit CI-Regeln, Architektur und ADR-Extraktion.",
   "agent-harness": "Bootstrappt, verifiziert und erzwingt Agent-Harness-Infrastruktur in Repositories.",
+  "aident-skill": "Verbindet AI Agents über Aident Loadout mit 1.000+ realen Apps und Tools wie Gmail, Slack, Linear, Notion, Firecrawl und Fal, inklusive 27.000+ ausführbaren Aktionen und vollständiger Audit-Historie.",
   "jira-integration": "Jira-API-Operationen und Wiki-Markup (zwei Sub-Skills).",
   "matrix-communication": "Versendet Nachrichten in Matrix-Räume.",
   "cli-tools": "Installiert fehlende CLI-Werkzeuge automatisch (74+ Tool-Katalog).",

--- a/site/src/_data/displayNames.json
+++ b/site/src/_data/displayNames.json
@@ -30,6 +30,7 @@
   "github-project": "GitHub Project",
   "github-release": "GitHub Release",
   "skill-repo": "Skill Repository",
+  "aident-skill": "Aident Skill",
   "jira-integration": "Jira Integration",
   "matrix-communication": "Matrix Communication",
   "context7": "Context7",

--- a/site/src/_data/groups.js
+++ b/site/src/_data/groups.js
@@ -90,6 +90,7 @@ export default {
       slugs: [
         "jira-integration",
         "matrix-communication",
+        "aident-skill",
         "cli-tools",
         "context7",
         "data-tools",


### PR DESCRIPTION
## Summary
- add Aident Skill to the Claude Code marketplace catalog as a GitHub source reference
- add the matching README catalog row and update the displayed skill count
- add site presentation metadata for the generated listing, including display name, group placement, and German description

## Notes
This follows the repository guidance in `README.md` / `AGENTS.md`: marketplace entries live in `.claude-plugin/marketplace.json`, point to the source skill repository, and have matching catalog/presentation metadata.

## Validation
- `./scripts/validate.sh`
- `GITHUB_TOKEN=$(gh auth token) npm_config_cache=/tmp/claude-code-marketplace-npm-cache npm --prefix site run fetch:readmes`
- `npm_config_cache=/tmp/claude-code-marketplace-npm-cache npm --prefix site run check`
- `git diff --check`
