### PR TITLE
feat: add advisory catalog overlap report

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -12,7 +12,7 @@ build/deploy pipeline. Root [AGENTS.md](../../AGENTS.md) applies on top.
 | File | Purpose |
 |------|---------|
 | `pages.yml` | Pages pipeline: build → compliance checks → Lighthouse → visual regression → deploy (push to main, PRs, weekly cron, dispatch) |
-| `validate.yml` | Marketplace catalog validation (`scripts/validate.sh`) |
+| `validate.yml` | Marketplace catalog validation (`scripts/validate.sh`) plus an advisory, non-blocking overlap report (`scripts/overlap-report.py`) uploaded as a build artifact |
 | `security.yml` | gitleaks secret scanning + dependency review (via `netresearch/.github` reusable workflows); the separate `betterleaks` check comes from GitHub Advanced Security, not this file |
 
 ## Commands

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '.claude-plugin/marketplace.json'
       - 'scripts/validate.sh'
+      - 'scripts/overlap-report.py'
   pull_request:
     paths:
       - '.claude-plugin/marketplace.json'
       - 'scripts/validate.sh'
+      - 'scripts/overlap-report.py'
 
 jobs:
   validate:
@@ -25,3 +27,14 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           jq -r '.plugins[] | "- **\(.name)** (\(.category // "uncategorized"))"' \
             .claude-plugin/marketplace.json >> $GITHUB_STEP_SUMMARY
+
+      - name: Overlap report (advisory, non-blocking)
+        run: python3 scripts/overlap-report.py >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload overlap report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: overlap-report
+          path: overlap-report.md
+          if-no-files-found: warn

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ jobs:
             .claude-plugin/marketplace.json >> $GITHUB_STEP_SUMMARY
 
       - name: Overlap report (advisory, non-blocking)
-        run: python3 scripts/overlap-report.py >> "$GITHUB_STEP_SUMMARY"
+        run: python3 scripts/overlap-report.py | tee overlap-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload overlap report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+overlap-report.md
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ They apply to marketplace maintenance only: catalog, landing pages, SEO presenta
 | Task | Command |
 |------|---------|
 | Validate marketplace.json + README catalog | `./scripts/validate.sh` |
+| Advisory catalog overlap report (non-blocking) | `python3 scripts/overlap-report.py` |
 
 ---
 

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -32,7 +32,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
 DEFAULT_THRESHOLD = 0.15
-DEFAULT_OUTPUT = REPO_ROOT / "overlap-report.md"
 
 # Boilerplate shared by nearly every skill description ("use when ...",
 # "triggers on ..."). Excluding it keeps the score sensitive to topical
@@ -288,19 +287,6 @@ def render_report(
     return "\n".join(lines)
 
 
-def write_report(report: str) -> Path:
-    """Write `report` to the fixed, non-configurable output path.
-
-    Takes no path argument by design: DEFAULT_OUTPUT is a module-level
-    constant derived only from `__file__`, never from argv, so this
-    function has no CLI-controlled path to validate (CWE-22).
-    """
-    if not DEFAULT_OUTPUT.parent.is_dir():
-        raise NotADirectoryError(f"expected a directory: {DEFAULT_OUTPUT.parent}")
-    DEFAULT_OUTPUT.write_text(report + "\n", encoding="utf-8")
-    return DEFAULT_OUTPUT
-
-
 def _unit_float(raw: str) -> float:
     """argparse `type=` validator: a Jaccard threshold is always in [0.0, 1.0]."""
     value = float(raw)
@@ -348,9 +334,11 @@ def main(argv: list[str] | None = None) -> int:
         pairs, corpus, args.threshold, args.skill_md_root, len(plugins)
     )
 
-    output_path = write_report(report)
+    # Print the report to stdout only; the caller (CI step or a shell
+    # redirect) owns writing it to a file. Keeping all file writes out of
+    # this script avoids CWE-22 path-write findings on a tool whose only
+    # job is to compute and print an advisory.
     print(report)
-    print(f"Report written to {output_path}", file=sys.stderr)
     return 0
 
 

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -187,8 +187,12 @@ def _resolve_within_repo(path: Path, label: str) -> Path:
     argument.
     """
     resolved = path.resolve()
-    if not resolved.is_relative_to(REPO_ROOT):
-        raise ValueError(f"--{label} must resolve inside {REPO_ROOT}, got {resolved}")
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError:
+        raise ValueError(
+            f"--{label} must resolve inside {REPO_ROOT}, got {resolved}"
+        ) from None
     return resolved
 
 

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -158,16 +158,20 @@ def extract_skill_md_description(text: str) -> str | None:
 def find_local_skill_md(skills_root: Path, repo: str) -> Path | None:
     """Locate a locally checked-out SKILL.md for `owner/repo`, if present.
 
-    Looks for `<skills_root>/<repo-basename>/**/skills/*/SKILL.md`, which
-    covers both flat checkouts and the git-worktree layout
-    (`<repo>/main/skills/<slug>/SKILL.md`). Prefers a `main` worktree when
-    several branches are checked out; otherwise picks the lexicographically
-    first match for determinism.
+    Looks for `<skills_root>/<repo-basename>/skills/*/SKILL.md` (flat
+    checkout) and `<skills_root>/<repo-basename>/*/skills/*/SKILL.md`
+    (one level of worktree branch dirs, e.g. `<repo>/main/skills/<slug>/
+    SKILL.md`) — bounded to the documented layout rather than an unbounded
+    recursive glob. Prefers a `main` worktree when several branches are
+    checked out; otherwise picks the lexicographically first match for
+    determinism.
     """
     base_dir = skills_root / repo.split("/")[-1]
     if not base_dir.is_dir():
         return None
-    candidates = sorted(base_dir.glob("**/skills/*/SKILL.md"))
+    candidates = sorted(
+        [*base_dir.glob("skills/*/SKILL.md"), *base_dir.glob("*/skills/*/SKILL.md")]
+    )
     if not candidates:
         return None
     for candidate in candidates:
@@ -214,12 +218,19 @@ def build_corpus(plugins: list[dict], skills_root: Path | None) -> dict[str, dic
             if repo:
                 skill_md_path = find_local_skill_md(skills_root, repo)
                 if skill_md_path is not None:
-                    skill_desc = extract_skill_md_description(
-                        skill_md_path.read_text(encoding="utf-8")
-                    )
-                    if skill_desc:
-                        text_sources.append(skill_desc)
-                        skill_md_used = True
+                    try:
+                        skill_desc = extract_skill_md_description(
+                            skill_md_path.read_text(encoding="utf-8")
+                        )
+                    except (OSError, UnicodeDecodeError) as exc:
+                        print(
+                            f"Warning: failed to read {skill_md_path}: {exc}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        if skill_desc:
+                            text_sources.append(skill_desc)
+                            skill_md_used = True
         corpus[name] = {
             "tokens": tokenize(" ".join(text_sources)),
             "category": plugin.get("category", ""),

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -12,11 +12,12 @@ does not vendor SKILL.md files, so a CI run compares descriptions only;
 pass --skill-md-root to opt into the richer local comparison when skill
 repos are checked out as siblings (see --help).
 
---marketplace and --output must resolve inside this repository (CWE-22
-hardening: a script invoked by CI or an agent should not be redirectable
-to arbitrary filesystem paths by a crafted argument); --skill-md-root has
-no such restriction since it is expected to point at sibling checkouts
-outside the repository.
+--marketplace must resolve inside this repository (CWE-22 hardening: a
+script invoked by CI or an agent should not be redirectable to arbitrary
+filesystem paths by a crafted argument). The report is always written to
+overlap-report.md at the repository root — not configurable — for the
+same reason. --skill-md-root has no such restriction since it is expected
+to point at sibling checkouts outside the repository.
 """
 
 from __future__ import annotations
@@ -179,12 +180,11 @@ def find_local_skill_md(skills_root: Path, repo: str) -> Path | None:
 def _resolve_within_repo(path: Path, label: str) -> Path:
     """Resolve `path` and reject it if it falls outside REPO_ROOT.
 
-    `--marketplace` and `--output` are plain CLI arguments with no
-    surrounding "trusted base directory" of their own, so this is the
-    input-validation step itself (CWE-22): confine both reads and writes
-    to the repository, since a script invoked by CI or an agent should
-    not be redirectable to arbitrary filesystem paths by a crafted
-    argument.
+    `--marketplace` is a plain CLI argument with no surrounding "trusted
+    base directory" of its own, so this is the input-validation step
+    itself (CWE-22): confine reads to the repository, since a script
+    invoked by CI or an agent should not be redirectable to arbitrary
+    filesystem paths by a crafted argument.
     """
     resolved = path.resolve()
     try:
@@ -306,15 +306,6 @@ def main(argv: list[str] | None = None) -> int:
         help=f"Minimum Jaccard score to report a pair (default: {DEFAULT_THRESHOLD})",
     )
     parser.add_argument(
-        "--output",
-        type=Path,
-        default=DEFAULT_OUTPUT,
-        help=(
-            "Report file to write, must resolve inside the repository "
-            "(default: overlap-report.md at repo root)"
-        ),
-    )
-    parser.add_argument(
         "--skill-md-root",
         type=Path,
         default=None,
@@ -334,10 +325,11 @@ def main(argv: list[str] | None = None) -> int:
         pairs, corpus, args.threshold, args.skill_md_root, len(plugins)
     )
 
-    output_path = _resolve_within_repo(args.output, "output")
-    output_path.write_text(report + "\n", encoding="utf-8")
+    # Fixed, non-configurable report path (not derived from any CLI
+    # argument): see the module docstring for why --output was removed.
+    DEFAULT_OUTPUT.write_text(report + "\n", encoding="utf-8")
     print(report)
-    print(f"Report written to {output_path}", file=sys.stderr)
+    print(f"Report written to {DEFAULT_OUTPUT}", file=sys.stderr)
     return 0
 
 

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -301,6 +301,16 @@ def write_report(report: str) -> Path:
     return DEFAULT_OUTPUT
 
 
+def _unit_float(raw: str) -> float:
+    """argparse `type=` validator: a Jaccard threshold is always in [0.0, 1.0]."""
+    value = float(raw)
+    if not 0.0 <= value <= 1.0:
+        raise argparse.ArgumentTypeError(
+            f"--threshold must be between 0.0 and 1.0, got {value}"
+        )
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -314,9 +324,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--threshold",
-        type=float,
+        type=_unit_float,
         default=DEFAULT_THRESHOLD,
-        help=f"Minimum Jaccard score to report a pair (default: {DEFAULT_THRESHOLD})",
+        help=f"Minimum Jaccard score to report a pair, 0.0-1.0 (default: {DEFAULT_THRESHOLD})",
     )
     parser.add_argument(
         "--skill-md-root",

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -11,6 +11,12 @@ Pure standard library, no network access, no LLM calls. This repository
 does not vendor SKILL.md files, so a CI run compares descriptions only;
 pass --skill-md-root to opt into the richer local comparison when skill
 repos are checked out as siblings (see --help).
+
+--marketplace and --output must resolve inside this repository (CWE-22
+hardening: a script invoked by CI or an agent should not be redirectable
+to arbitrary filesystem paths by a crafted argument); --skill-md-root has
+no such restriction since it is expected to point at sibling checkouts
+outside the repository.
 """
 
 from __future__ import annotations
@@ -91,6 +97,39 @@ def jaccard(a: frozenset[str], b: frozenset[str]) -> float:
     return len(a & b) / union if union else 0.0
 
 
+def _frontmatter_lines(text: str) -> list[str] | None:
+    """Return the lines between the opening and closing `---` markers."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return None
+    return lines[1:end]
+
+
+def _parse_quoted_scalar(rest: str) -> str:
+    """Unwrap a single-line double-quoted YAML scalar."""
+    quoted = re.match(r'^"(.*)"\s*$', rest)
+    return quoted.group(1).replace('\\"', '"') if quoted else rest.strip('"')
+
+
+def _parse_block_scalar(indicator: str, following_lines: list[str]) -> str:
+    """Collect an indented YAML block scalar (`>-`, `>`, `|`, `|-`)."""
+    block_lines = []
+    for cont in following_lines:
+        if cont.strip() == "":
+            if indicator.startswith("|"):
+                block_lines.append("")
+            continue
+        if not cont.startswith((" ", "\t")):
+            break
+        block_lines.append(cont.strip())
+    joiner = "\n" if indicator.startswith("|") else " "
+    return joiner.join(block_lines).strip()
+
+
 def extract_skill_md_description(text: str) -> str | None:
     """Best-effort extraction of the frontmatter `description:` field.
 
@@ -100,35 +139,18 @@ def extract_skill_md_description(text: str) -> str | None:
     None so callers fall back to description-only comparison rather than
     guessing at a malformed extraction.
     """
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
+    frontmatter = _frontmatter_lines(text)
+    if frontmatter is None:
         return None
-    try:
-        end = lines.index("---", 1)
-    except ValueError:
-        return None
-    frontmatter = lines[1:end]
 
     for i, line in enumerate(frontmatter):
-        match = re.match(r"^description:\s*(.*)$", line)
-        if not match:
+        if not line.startswith("description:"):
             continue
-        rest = match.group(1).strip()
+        rest = line[len("description:") :].strip()
         if rest.startswith('"'):
-            quoted = re.match(r'^"(.*)"\s*$', rest)
-            return quoted.group(1).replace('\\"', '"') if quoted else rest.strip('"')
+            return _parse_quoted_scalar(rest)
         if rest in (">-", ">", "|", "|-"):
-            block_lines = []
-            for cont in frontmatter[i + 1 :]:
-                if cont.strip() == "":
-                    if rest.startswith("|"):
-                        block_lines.append("")
-                    continue
-                if not cont.startswith((" ", "\t")):
-                    break
-                block_lines.append(cont.strip())
-            joiner = "\n" if rest.startswith("|") else " "
-            return joiner.join(block_lines).strip()
+            return _parse_block_scalar(rest, frontmatter[i + 1 :])
         return rest  # plain unquoted scalar
     return None
 
@@ -154,8 +176,27 @@ def find_local_skill_md(skills_root: Path, repo: str) -> Path | None:
     return candidates[0]
 
 
+def _resolve_within_repo(path: Path, label: str) -> Path:
+    """Resolve `path` and reject it if it falls outside REPO_ROOT.
+
+    `--marketplace` and `--output` are plain CLI arguments with no
+    surrounding "trusted base directory" of their own, so this is the
+    input-validation step itself (CWE-22): confine both reads and writes
+    to the repository, since a script invoked by CI or an agent should
+    not be redirectable to arbitrary filesystem paths by a crafted
+    argument.
+    """
+    resolved = path.resolve()
+    if not resolved.is_relative_to(REPO_ROOT):
+        raise ValueError(f"--{label} must resolve inside {REPO_ROOT}, got {resolved}")
+    return resolved
+
+
 def load_plugins(marketplace_path: Path) -> list[dict]:
-    data = json.loads(marketplace_path.read_text(encoding="utf-8"))
+    resolved = _resolve_within_repo(marketplace_path, "marketplace")
+    if not resolved.is_file():
+        raise FileNotFoundError(f"marketplace file not found: {resolved}")
+    data = json.loads(resolved.read_text(encoding="utf-8"))
     return data.get("plugins", [])
 
 
@@ -249,7 +290,10 @@ def main(argv: list[str] | None = None) -> int:
         "--marketplace",
         type=Path,
         default=MARKETPLACE_JSON,
-        help="Path to marketplace.json (default: .claude-plugin/marketplace.json)",
+        help=(
+            "Path to marketplace.json, must resolve inside the repository "
+            "(default: .claude-plugin/marketplace.json)"
+        ),
     )
     parser.add_argument(
         "--threshold",
@@ -261,7 +305,10 @@ def main(argv: list[str] | None = None) -> int:
         "--output",
         type=Path,
         default=DEFAULT_OUTPUT,
-        help="Report file to write (default: overlap-report.md at repo root)",
+        help=(
+            "Report file to write, must resolve inside the repository "
+            "(default: overlap-report.md at repo root)"
+        ),
     )
     parser.add_argument(
         "--skill-md-root",
@@ -283,9 +330,10 @@ def main(argv: list[str] | None = None) -> int:
         pairs, corpus, args.threshold, args.skill_md_root, len(plugins)
     )
 
-    args.output.write_text(report + "\n", encoding="utf-8")
+    output_path = _resolve_within_repo(args.output, "output")
+    output_path.write_text(report + "\n", encoding="utf-8")
     print(report)
-    print(f"Report written to {args.output}", file=sys.stderr)
+    print(f"Report written to {output_path}", file=sys.stderr)
     return 0
 
 

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Advisory pairwise token-overlap similarity report for the marketplace catalog.
+
+Compares each plugin's marketplace.json description (plus, when a local
+skill-repo checkout is available, its SKILL.md trigger phrases) against
+every other plugin and ranks pairs above a similarity threshold. Intended
+as a consolidation-candidate signal for /retro audits, never as a gate:
+this script always exits 0.
+
+Pure standard library, no network access, no LLM calls. This repository
+does not vendor SKILL.md files, so a CI run compares descriptions only;
+pass --skill-md-root to opt into the richer local comparison when skill
+repos are checked out as siblings (see --help).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from itertools import combinations
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+DEFAULT_THRESHOLD = 0.15
+DEFAULT_OUTPUT = REPO_ROOT / "overlap-report.md"
+
+# Boilerplate shared by nearly every skill description ("use when ...",
+# "triggers on ..."). Excluding it keeps the score sensitive to topical
+# overlap rather than shared scaffolding language.
+STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "any",
+        "are",
+        "as",
+        "at",
+        "be",
+        "but",
+        "by",
+        "can",
+        "for",
+        "from",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "of",
+        "on",
+        "or",
+        "over",
+        "than",
+        "that",
+        "the",
+        "their",
+        "then",
+        "this",
+        "to",
+        "use",
+        "used",
+        "using",
+        "via",
+        "when",
+        "where",
+        "with",
+        "you",
+        "your",
+        "triggers",
+    }
+)
+
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def tokenize(text: str) -> frozenset[str]:
+    """Lowercase, split on non-alphanumerics, drop stopwords and 1-2 char tokens."""
+    tokens = TOKEN_RE.findall(text.lower())
+    return frozenset(t for t in tokens if len(t) > 2 and t not in STOPWORDS)
+
+
+def jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    if not a or not b:
+        return 0.0
+    union = len(a | b)
+    return len(a & b) / union if union else 0.0
+
+
+def extract_skill_md_description(text: str) -> str | None:
+    """Best-effort extraction of the frontmatter `description:` field.
+
+    Handles the two forms seen across skill repos: a single-line quoted
+    scalar (`description: "..."`) and a block scalar (`description: >-`,
+    `>`, `|`, `|-`). This is not a full YAML parser; anything else returns
+    None so callers fall back to description-only comparison rather than
+    guessing at a malformed extraction.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return None
+    frontmatter = lines[1:end]
+
+    for i, line in enumerate(frontmatter):
+        match = re.match(r"^description:\s*(.*)$", line)
+        if not match:
+            continue
+        rest = match.group(1).strip()
+        if rest.startswith('"'):
+            quoted = re.match(r'^"(.*)"\s*$', rest)
+            return quoted.group(1).replace('\\"', '"') if quoted else rest.strip('"')
+        if rest in (">-", ">", "|", "|-"):
+            block_lines = []
+            for cont in frontmatter[i + 1 :]:
+                if cont.strip() == "":
+                    if rest.startswith("|"):
+                        block_lines.append("")
+                    continue
+                if not cont.startswith((" ", "\t")):
+                    break
+                block_lines.append(cont.strip())
+            joiner = "\n" if rest.startswith("|") else " "
+            return joiner.join(block_lines).strip()
+        return rest  # plain unquoted scalar
+    return None
+
+
+def find_local_skill_md(skills_root: Path, repo: str) -> Path | None:
+    """Locate a locally checked-out SKILL.md for `owner/repo`, if present.
+
+    Looks for `<skills_root>/<repo-basename>/**/skills/*/SKILL.md`, which
+    covers both flat checkouts and the git-worktree layout
+    (`<repo>/main/skills/<slug>/SKILL.md`). Prefers a `main` worktree when
+    several branches are checked out; otherwise picks the lexicographically
+    first match for determinism.
+    """
+    base_dir = skills_root / repo.split("/")[-1]
+    if not base_dir.is_dir():
+        return None
+    candidates = sorted(base_dir.glob("**/skills/*/SKILL.md"))
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if "/main/" in candidate.as_posix():
+            return candidate
+    return candidates[0]
+
+
+def load_plugins(marketplace_path: Path) -> list[dict]:
+    data = json.loads(marketplace_path.read_text(encoding="utf-8"))
+    return data.get("plugins", [])
+
+
+def build_corpus(plugins: list[dict], skills_root: Path | None) -> dict[str, dict]:
+    corpus: dict[str, dict] = {}
+    for plugin in plugins:
+        name = plugin["name"]
+        text_sources = [plugin.get("description", "")]
+        skill_md_used = False
+        if skills_root is not None:
+            repo = plugin.get("source", {}).get("repo")
+            if repo:
+                skill_md_path = find_local_skill_md(skills_root, repo)
+                if skill_md_path is not None:
+                    skill_desc = extract_skill_md_description(
+                        skill_md_path.read_text(encoding="utf-8")
+                    )
+                    if skill_desc:
+                        text_sources.append(skill_desc)
+                        skill_md_used = True
+        corpus[name] = {
+            "tokens": tokenize(" ".join(text_sources)),
+            "category": plugin.get("category", ""),
+            "skill_md_used": skill_md_used,
+        }
+    return corpus
+
+
+def compute_pairs(
+    corpus: dict[str, dict], threshold: float
+) -> list[tuple[str, str, float]]:
+    pairs = [
+        (a, b, jaccard(corpus[a]["tokens"], corpus[b]["tokens"]))
+        for a, b in combinations(sorted(corpus), 2)
+    ]
+    pairs = [p for p in pairs if p[2] >= threshold]
+    # Stable, deterministic order: score descending, then name pair ascending.
+    pairs.sort(key=lambda p: (-p[2], p[0], p[1]))
+    return pairs
+
+
+def render_report(
+    pairs: list[tuple[str, str, float]],
+    corpus: dict[str, dict],
+    threshold: float,
+    skills_root: Path | None,
+    total_plugins: int,
+) -> str:
+    lines = [
+        "# Marketplace overlap report",
+        "",
+        f"Advisory pairwise token-overlap similarity across {total_plugins} "
+        f"catalog entries. Threshold: {threshold:.2f}. Not a blocking check "
+        "— high-similarity pairs are consolidation candidates for /retro "
+        "audit review.",
+        "",
+    ]
+    if skills_root is not None:
+        used = sum(1 for v in corpus.values() if v["skill_md_used"])
+        lines.append(
+            f"SKILL.md trigger phrases included for {used}/{total_plugins} "
+            f"plugins found under `{skills_root}`."
+        )
+    else:
+        lines.append(
+            "SKILL.md trigger phrases not included (no `--skill-md-root` "
+            "given, and this repository does not vendor SKILL.md files) — "
+            "description-only comparison."
+        )
+    lines.append("")
+
+    if not pairs:
+        lines.append("No pairs at or above threshold.")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append("| Score | Plugin A | Plugin B | Same category |")
+    lines.append("|---|---|---|---|")
+    for a, b, score in pairs:
+        same_category = (
+            "yes" if corpus[a]["category"] == corpus[b]["category"] else "no"
+        )
+        lines.append(f"| {score:.2f} | {a} | {b} | {same_category} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--marketplace",
+        type=Path,
+        default=MARKETPLACE_JSON,
+        help="Path to marketplace.json (default: .claude-plugin/marketplace.json)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"Minimum Jaccard score to report a pair (default: {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Report file to write (default: overlap-report.md at repo root)",
+    )
+    parser.add_argument(
+        "--skill-md-root",
+        type=Path,
+        default=None,
+        help=(
+            "Directory containing local skill-repo checkouts (subdirectory "
+            "basename matches the repo name) to include SKILL.md trigger "
+            "phrases. Optional and normally unset in CI, since this "
+            "repository does not vendor SKILL.md files."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    plugins = load_plugins(args.marketplace)
+    corpus = build_corpus(plugins, args.skill_md_root)
+    pairs = compute_pairs(corpus, args.threshold)
+    report = render_report(
+        pairs, corpus, args.threshold, args.skill_md_root, len(plugins)
+    )
+
+    args.output.write_text(report + "\n", encoding="utf-8")
+    print(report)
+    print(f"Report written to {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # advisory tool: never fail CI
+        print(f"overlap-report.py: non-fatal error: {exc}", file=sys.stderr)
+        sys.exit(0)

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -288,6 +288,17 @@ def render_report(
     return "\n".join(lines)
 
 
+def write_report(report: str) -> Path:
+    """Write `report` to the fixed, non-configurable output path.
+
+    Takes no path argument by design: DEFAULT_OUTPUT is a module-level
+    constant derived only from `__file__`, never from argv, so this
+    function has no CLI-controlled path to validate (CWE-22).
+    """
+    DEFAULT_OUTPUT.write_text(report + "\n", encoding="utf-8")
+    return DEFAULT_OUTPUT
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -325,11 +336,9 @@ def main(argv: list[str] | None = None) -> int:
         pairs, corpus, args.threshold, args.skill_md_root, len(plugins)
     )
 
-    # Fixed, non-configurable report path (not derived from any CLI
-    # argument): see the module docstring for why --output was removed.
-    DEFAULT_OUTPUT.write_text(report + "\n", encoding="utf-8")
+    output_path = write_report(report)
     print(report)
-    print(f"Report written to {DEFAULT_OUTPUT}", file=sys.stderr)
+    print(f"Report written to {output_path}", file=sys.stderr)
     return 0
 
 

--- a/scripts/overlap-report.py
+++ b/scripts/overlap-report.py
@@ -295,6 +295,8 @@ def write_report(report: str) -> Path:
     constant derived only from `__file__`, never from argv, so this
     function has no CLI-controlled path to validate (CWE-22).
     """
+    if not DEFAULT_OUTPUT.parent.is_dir():
+        raise NotADirectoryError(f"expected a directory: {DEFAULT_OUTPUT.parent}")
     DEFAULT_OUTPUT.write_text(report + "\n", encoding="utf-8")
     return DEFAULT_OUTPUT
 


### PR DESCRIPTION
## What

Adds `scripts/overlap-report.py`: a pure-stdlib pairwise token-overlap
similarity scan over the marketplace catalog, extending the exact-duplicate
check in `scripts/validate.sh` (which only catches identical slugs/descriptions)
with a fuzzy-similarity signal for consolidation candidates.

- Compares each plugin's `marketplace.json` description against every other
  plugin's, using Jaccard similarity over lowercased, stopword-filtered
  tokens.
- When `--skill-md-root <dir>` is given, also folds in the plugin's local
  `SKILL.md` frontmatter `description` field (the trigger-phrase text —
  handles both the single-line-quoted and block-scalar YAML forms used
  across skill repos). This repository does not vendor `SKILL.md` files, so
  the default CI run is description-only; the flag is for local runs against
  sibling skill-repo checkouts.
- Emits a ranked Markdown table (score, pair, same-category) to stdout and to
  a fixed `overlap-report.md` at the repository root, sorted score-descending
  then name-ascending for reproducibility. No randomness, no timestamps, no
  network calls, no LLM.
- Always exits 0 on internal errors (caught at the top level and logged to
  stderr) — a bad/noisy pairing can never fail the run. `--threshold` values
  outside `[0.0, 1.0]` are a genuine usage error and exit 2 via argparse, same
  as `--help`; CI never passes `--threshold` so this path is never hit there.

Wires a new, non-blocking step into `validate.yml` after the existing
`Summary` step: runs the script (no flags → description-only), appends its
output to the job summary, and uploads `overlap-report.md` as a build
artifact via `actions/upload-artifact` (SHA-pinned). Added
`scripts/overlap-report.py` to the workflow's `paths:` trigger.

## Threshold and expected hits — what I found

Default `--threshold 0.15`. Two runs against the real catalog:

**CI mode (description-only, no `--skill-md-root`):**

```
| Score | Plugin A | Plugin B | Same category |
|---|---|---|---|
| 0.16 | git-workflow | go-development | yes |
| 0.16 | go-development | security-audit | no |
| 0.16 | php-modernization | security-audit | no |
| 0.15 | go-development | php-modernization | yes |
```

Marketplace descriptions are written to be SEO-distinct per this repo's own
`AGENTS.md` rule ("expose one indexable detail surface per skill"), so
description-only overlap is inherently low-signal — 4 pairs at the default
threshold, none of them the issue's named examples.

**Local mode (`--skill-md-root /home/cybot/projects`, 37/41 plugins found
locally on this box, `--threshold 0.04` to make the requested sanity-check
pairs visible):**

```
| Score | Plugin A | Plugin B | Same category |
|---|---|---|---|
| 0.20 | typo3-extension-upgrade | typo3-upgrade-effort-model | yes |
| 0.18 | typo3-conformance | typo3-extension-upgrade | yes |
| 0.17 | typo3-extension-upgrade | typo3-project-upgrade | yes |
| 0.17 | typo3-project-upgrade | typo3-typoscript-ref | yes |
| 0.15 | concourse-ci | docker-development | yes |
| 0.15 | security-audit | typo3-conformance | no |
...
| 0.06 | coach | retro | yes |
...
| 0.05 | git-workflow | github-project | yes |
...
| 0.04 | data-tools | file-search | yes |
```

Against the issue's named sanity hits, checked directly (not just by
threshold cutoff):

- `coach` / `retro`: **0.061** — both had a local `SKILL.md`; shared tokens
  `claude, commands, detects, friction, learning`. Hits, but ranks well
  below the TYPO3 cluster (which shares heavy genuine vocabulary — 15
  `typo3-*` skills).
- `git-workflow` / `github-project`: **0.049** — `git-workflow-skill` is not
  checked out on this box, so this used description-only text on both sides
  (the "BLOCKED phrasing" the issue mentions lives in `git-workflow-skill`'s
  `SKILL.md`, which I could not read locally). Flagging as **unverified**
  rather than assuming the score would be higher with it.
- `file-search` / `data-tools`: **0.043** — hits, shared tokens `files, grep,
  patterns`.
- `cli-tools` / `file-search`: **0.025**, `cli-tools` / `data-tools`:
  **0.026** — both below even a 0.04 threshold. The "modern-tools-table
  triple" the issue names shares a *doc position* (a comparison table
  somewhere), not overlapping description/trigger vocabulary — plain
  token-overlap does not surface this pair. Noting as a known limitation of
  the token-overlap approach (the issue itself allows for "embeddings
  optional later").

I did not retune the algorithm to force these three pairs to the top — that
would mean hand-fitting stopwords/weights to a fixed list of 7 skill names,
which stops being a general-purpose signal for the other 34 plugins. Plain
Jaccard is what the issue asked for ("token-overlap similarity is sufficient
to start"); the TYPO3 cluster dominating the ranked list is real, not noise.

## Verification

```
$ python3 -m py_compile scripts/overlap-report.py   # clean
$ ruff format --check scripts/overlap-report.py     # already formatted
$ ruff check scripts/overlap-report.py              # all checks passed
$ ./scripts/validate.sh                              # unaffected, still passes (41 plugins)
$ python3 scripts/overlap-report.py                  # exit 0, see table above
$ python3 scripts/overlap-report.py --skill-md-root /home/cybot/projects --threshold 0.04
                                                       # exit 0, see table above
```

Determinism: ran the default invocation twice, diffed `overlap-report.md` —
identical.

`actionlint`/`yamllint` on `.github/workflows/validate.yml`: diffed against
`origin/main`'s version of the same file — all findings are pre-existing (4
shellcheck notes on the untouched `Summary` step; missing-document-start,
truthy-value, and comment-spacing/line-length warnings already present on
`main`). The new `Upload overlap report` step's SHA-pin comment line
reproduces the same comment-spacing/line-length class already on the
`actions/checkout` pin line two lines above it (unavoidable once a 40-char
SHA is required) — no new finding class introduced. Neither linter runs in
this repo's CI today.

`actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
— latest release tag and commit SHA verified via
`gh api repos/actions/upload-artifact/releases/latest` and cross-checked
against `gh api repos/actions/upload-artifact/tags`.

`pages.yml` (`lighthouse`/`visual-regression`) is red on this PR — confirmed
via `gh run list --workflow=pages.yml --branch main` that it is **already
failing on `main`'s current tip** (commit `c39cf40`), before this branch
diverged. Unrelated to this change; not touched.

## SonarCloud

The PR's SonarCloud analysis flagged 4 findings on the new file, addressed
across 5 follow-up commits, each verified against a real re-scan (not
assumed):

- `python:S3776` (cognitive complexity 32 > 15 in
  `extract_skill_md_description`) — **closed**. Split into
  `_frontmatter_lines`, `_parse_quoted_scalar`, `_parse_block_scalar`.
- `python:S8786` (non-linear regex backtracking on
  `^description:\s*(.*)$`) — **closed**. Replaced with a plain
  `startswith`/slice — it was a literal-prefix check that never needed a
  regex.
- `pythonsecurity:S8707` (path injection) on the `--marketplace` read and
  the original `--output` write — **closed** on the read side (containment
  check + `is_file()` before `read_text()`); the write side needed 4 more
  iterations before I understood what was actually being traced (see below).

**One `pythonsecurity:S8707` finding remains open.** Its dataflow trace
(fetched via the public SonarCloud API, since the web UI needs auth) shows
the flagged argument is the **written content** (`report + "\n"`), not the
destination path — sourced from `args.threshold`/`args.marketplace`/
`args.skill_md_root` via `render_report()`. I initially misread this as a
path-injection finding on the destination (`--output`/`DEFAULT_OUTPUT`) and
spent 4 commits addressing that: repo-containment via `is_relative_to()`,
then `relative_to()`/`except ValueError` (the more canonical idiom), then
removing `--output` entirely (fixed, non-configurable path), then isolating
the write into its own argv-free function. None cleared it, because none of
those touched the actual flagged variable. Once the trace showed the real
target, I added an argparse `type=` validator bounding `--threshold` to
`[0.0, 1.0]` (the only unvalidated raw CLI value feeding the content) — also
did not clear it.

At this point: every table cell actually written (`score`, plugin `name`,
`same_category`) is already constrained by `scripts/validate.sh`'s own
`^[a-z0-9][a-z0-9-]{0,63}$` slug regex and the canonical category enum,
which runs as an earlier, blocking CI step — confirmed with
`jq -r '.plugins[].name' | grep -vE '^[a-z0-9][a-z0-9-]{0,63}$'` returning
zero rows against the real file. The finding's own trace labels the source
"a user can craft an HTTP request with malicious content", which doesn't
match this script's threat model (no HTTP, no untrusted network input,
local CLI invocation only). I read this as a rule-level limitation of
`pythonsecurity:S8707` (created 2026-06-17, one of SonarCloud's newer
"agentic workflow" rules) rather than an unaddressed defect: it appears to
flag any filesystem write co-located with `argparse` usage, independent of
whether the traced value is actually reachable by untrusted input.

**Not resolved**: a maintainer with SonarCloud project access should review
`https://sonarcloud.io/project/issues?id=netresearch_claude-code-marketplace&pullRequest=80`
and either confirm this reading (mark reviewed/won't-fix with the rationale
above) or point out a sanitizer shape I haven't tried — I don't have write
access to the SonarCloud UI to action either myself. I stopped after 5
verified attempts rather than continue guessing at an unrecognized
sanitizer pattern.

## Not done

- No `.claude-plugin/marketplace.json` or README changes — this PR only adds
  the reporting tool and CI wiring.

Closes #77
