### PR TITLE
feat(marketplace): add optional value_type facet per plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,7 +41,8 @@
         "source": "github",
         "repo": "netresearch/typo3-ddev-skill"
       },
-      "category": "development"
+      "category": "development",
+      "value_type": "org-convention"
     },
     {
       "name": "typo3-core-contributions",
@@ -59,7 +60,8 @@
         "source": "github",
         "repo": "netresearch/typo3-conformance-skill"
       },
-      "category": "development"
+      "category": "development",
+      "value_type": "version-facts"
     },
     {
       "name": "typo3-site-conformance",
@@ -140,7 +142,8 @@
         "source": "github",
         "repo": "netresearch/security-audit-skill"
       },
-      "category": "security"
+      "category": "security",
+      "value_type": "guardrail"
     },
     {
       "name": "typo3-ckeditor5",
@@ -167,7 +170,8 @@
         "source": "github",
         "repo": "netresearch/github-project-skill"
       },
-      "category": "development"
+      "category": "development",
+      "value_type": "org-convention"
     },
     {
       "name": "jujutsu-workflow",
@@ -212,7 +216,8 @@
         "source": "github",
         "repo": "netresearch/data-tools-skill"
       },
-      "category": "development"
+      "category": "development",
+      "value_type": "automation-script"
     },
     {
       "name": "coach",
@@ -374,7 +379,8 @@
         "source": "github",
         "repo": "netresearch/retro-skill"
       },
-      "category": "productivity"
+      "category": "productivity",
+      "value_type": "failure-patterns"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,16 @@ Use **exactly one** of these values in `plugins[].category` — do not invent ne
 
 ---
 
+## Value type (optional)
+
+`plugins[].value_type` is an **optional** classifier mapping a skill to the six-category value rubric from the skill value-gate program ([skill-repo-skill#143](https://github.com/netresearch/skill-repo-skill/issues/143)). Allowed values:
+
+`automation-script` · `org-convention` · `version-facts` · `failure-patterns` · `guardrail`
+
+`guardrail` covers two rubric categories (inference suppression and anti-rationalization guards). Absence of the field is valid — `scripts/validate.sh` only checks the enum when the field is present. Populate it as skills are audited against the rubric; do not backfill guesses.
+
+---
+
 ## SEO and discovery rules (marketplace copy)
 
 Marketplace-facing text **must**:

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -54,6 +54,22 @@ if [ -n "$BAD_CATEGORIES" ]; then
 fi
 echo "✓ Categories within canonical set"
 
+# Canonical value types — optional field, keep in sync with AGENTS.md.
+# Maps to the A1 six-category value rubric (skill-repo-skill#143); inference
+# suppression and anti-rationalization guards both map to "guardrail".
+ALLOWED_VALUE_TYPES='automation-script org-convention version-facts failure-patterns guardrail'
+BAD_VALUE_TYPES=$(jq -r --arg allowed "$ALLOWED_VALUE_TYPES" '
+    [.plugins[] | select(.value_type != null) | select((.value_type) as $v | ($allowed | split(" ")) | index($v) | not)
+                | "\(.name)=\(.value_type)"]
+    | join("\n")
+' "$MARKETPLACE")
+if [ -n "$BAD_VALUE_TYPES" ]; then
+    echo "✗ Non-canonical value_type (allowed: $ALLOWED_VALUE_TYPES):"
+    printf '%s\n' "$BAD_VALUE_TYPES" | sed 's/^/    /'
+    exit 1
+fi
+echo "✓ value_type within canonical set (where present; field is optional)"
+
 # Slugs must be lowercase / hyphens / ≤ 64 chars.
 BAD_SLUGS=$(jq -r '
     [.plugins[].name | select(test("^[a-z0-9][a-z0-9-]{0,63}$") | not)]

--- a/site/src/_data/skills.js
+++ b/site/src/_data/skills.js
@@ -19,6 +19,7 @@ const MARKETPLACE = resolve(__dirname, "../../../.claude-plugin/marketplace.json
 const CACHE_DIR = resolve(__dirname, "../../cache/skills-readme");
 
 import categories from "./categories.js";
+import valueTypes from "./valueTypes.js";
 import groups from "./groups.js";
 import descriptionsDe from "./descriptions_de.json" with { type: "json" };
 import { displayName } from "./_helpers/display-name.js";
@@ -87,6 +88,9 @@ export default function () {
       category: plugin.category,
       categoryLabelEn: categories.labels.en[plugin.category],
       categoryLabelDe: categories.labels.de[plugin.category],
+      valueType: plugin.value_type || null,
+      valueTypeLabelEn: plugin.value_type ? valueTypes.labels.en[plugin.value_type] : null,
+      valueTypeLabelDe: plugin.value_type ? valueTypes.labels.de[plugin.value_type] : null,
       group: groupOf(plugin.name),
       repo: plugin.source?.repo,
       repoUrl: plugin.source?.repo ? `https://github.com/${plugin.source.repo}` : null,

--- a/site/src/_data/valueTypes.js
+++ b/site/src/_data/valueTypes.js
@@ -1,0 +1,34 @@
+/**
+ * Canonical value_type enum per AGENTS.md §Value type (optional).
+ * Mirrors the 5 values enforced by scripts/validate.sh. Maps to the A1
+ * six-category value rubric (skill-repo-skill#143) — "guardrail" covers
+ * both inference suppression and anti-rationalization guards.
+ *
+ * The field is optional: skills without a value_type simply don't render
+ * this facet.
+ */
+export default {
+  enum: [
+    "automation-script",
+    "org-convention",
+    "version-facts",
+    "failure-patterns",
+    "guardrail",
+  ],
+  labels: {
+    en: {
+      "automation-script": "Automation script",
+      "org-convention": "Org convention",
+      "version-facts": "Version facts",
+      "failure-patterns": "Failure patterns",
+      guardrail: "Guardrail",
+    },
+    de: {
+      "automation-script": "Automatisierungsskript",
+      "org-convention": "Organisationskonvention",
+      "version-facts": "Versionsfakten",
+      "failure-patterns": "Fehlermuster",
+      guardrail: "Guardrail",
+    },
+  },
+};

--- a/site/src/_includes/layouts/skill.njk
+++ b/site/src/_includes/layouts/skill.njk
@@ -16,6 +16,9 @@ layout: layouts/base.njk
 <article class="skill-detail">
   <header class="skill-detail__header">
     <span class="skill-detail__category">{{ categoryLabel }}</span>
+    {% if skill.valueType %}
+      <span class="skill-detail__value-type">{{ valueTypeLabel }}</span>
+    {% endif %}
     <h1>{{ skill.displayName }}</h1>
     <p class="lead">{{ description }}</p>
     {% if skill.version %}

--- a/site/src/_includes/partials/skill-card.njk
+++ b/site/src/_includes/partials/skill-card.njk
@@ -1,5 +1,8 @@
 <article class="skill-card">
   <span class="skill-card__category" aria-label="Category">{{ categoryLabels[skill.category] or skill.category }}</span>
+  {% if skill.valueType %}
+    <span class="skill-card__value-type" aria-label="Value type">{{ valueTypeLabels[skill.valueType] or skill.valueType }}</span>
+  {% endif %}
   <h3 class="skill-card__title">
     <a href="{{ ('/' ~ lang ~ '/skills/' ~ skill.slug ~ '/') | url }}">{{ skill.displayName }}</a>
   </h3>

--- a/site/src/assets/css/main.css
+++ b/site/src/assets/css/main.css
@@ -218,6 +218,17 @@ pre {
   margin-bottom: var(--spacing-sm);
 }
 
+.skill-card__value-type {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0 0.35em;
+  margin-left: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
+}
+
 .skill-card__description {
   font-size: var(--font-size-sm);
   color: var(--color-text-primary);
@@ -819,6 +830,17 @@ body[data-install-mode="composer-skills"] .skill-card__installs > .install--comp
   letter-spacing: 0.1em;
   color: var(--color-primary-dark);
   font-weight: 700;
+  margin-bottom: var(--spacing-md);
+}
+
+.skill-detail__value-type {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0 0.35em;
+  margin-left: var(--spacing-xs);
   margin-bottom: var(--spacing-md);
 }
 

--- a/site/src/de/de.11tydata.js
+++ b/site/src/de/de.11tydata.js
@@ -10,5 +10,6 @@ export default {
   eleventyComputed: {
     t: (data) => data.i18n.de,
     categoryLabels: (data) => data.categories.labels.de,
+    valueTypeLabels: (data) => data.valueTypes.labels.de,
   },
 };

--- a/site/src/de/skills/skill.njk
+++ b/site/src/de/skills/skill.njk
@@ -9,6 +9,7 @@ eleventyComputed:
   title: "{{ skill.displayName }} · Netresearch Skills Marketplace"
   description: "{{ skill.descriptionDe }}"
   categoryLabel: "{{ skill.categoryLabelDe }}"
+  valueTypeLabel: "{{ skill.valueTypeLabelDe }}"
   ogImage: "/assets/og/{{ skill.slug }}.png"
   hreflangAlternate:
     lang: "en"

--- a/site/src/en/en.11tydata.js
+++ b/site/src/en/en.11tydata.js
@@ -15,5 +15,6 @@ export default {
   eleventyComputed: {
     t: (data) => data.i18n.en,
     categoryLabels: (data) => data.categories.labels.en,
+    valueTypeLabels: (data) => data.valueTypes.labels.en,
   },
 };

--- a/site/src/en/skills/skill.njk
+++ b/site/src/en/skills/skill.njk
@@ -9,6 +9,7 @@ eleventyComputed:
   title: "{{ skill.displayName }} · Netresearch Skills Marketplace"
   description: "{{ skill.descriptionEn }}"
   categoryLabel: "{{ skill.categoryLabelEn }}"
+  valueTypeLabel: "{{ skill.valueTypeLabelEn }}"
   ogImage: "/assets/og/{{ skill.slug }}.png"
   hreflangAlternate:
     lang: "de"


### PR DESCRIPTION
## What

Part of the skill value-gate program — epic https://github.com/netresearch/skill-repo-skill/issues/142.

1. Adds an optional `value_type` field per plugin in `.claude-plugin/marketplace.json`, allowlisted in `scripts/validate.sh` the same way as the existing `category` field. Maps to the A1 six-category value rubric (https://github.com/netresearch/skill-repo-skill/issues/143):
   - `automation-script`
   - `org-convention`
   - `version-facts`
   - `failure-patterns`
   - `guardrail` (covers both "inference suppression" and "anti-rationalization guards" from the rubric)

   The field is optional — absence does not fail validation.

2. Populates `value_type` for 6 example plugins, one per allowed value (plus a second `org-convention` for coverage): `typo3-ddev`=org-convention, `security-audit`=guardrail, `data-tools`=automation-script, `typo3-conformance`=version-facts, `github-project`=org-convention, `retro`=failure-patterns. The remaining ~35 plugins are left unset for a later pass.

3. Surfaces `value_type` as a small label next to the category on skill cards (`site/src/_includes/partials/skill-card.njk`) and skill detail pages (`site/src/_includes/layouts/skill.njk`), localized EN/DE via a new `site/src/_data/valueTypes.js` label file mirroring `categories.js`.

4. Documents the new field/enum in root `AGENTS.md` (`§Value type (optional)`), mirroring the existing `§Canonical categories` section.

## Deferred (out of scope for this PR)

The A/B measured-delta badges (eval count + delta) from issue #78 are **not** wired. Their data source (`skill-repo-skill`'s `docs/dashboard/data/results.json`) is produced by the scheduled A/B eval pipeline, which is disabled by team decision (no LLM in pipelines for now — see A5/A6 in the epic). Wiring that display is deferred until that pipeline is re-enabled.

## Verification

- `jq empty .claude-plugin/marketplace.json` — valid JSON
- `./scripts/validate.sh` — passes, including a new `value_type within canonical set` check (verified it also correctly fails on an injected bad value, then restored)
- `bash -n scripts/validate.sh` + `shellcheck -x -S error scripts/validate.sh` — clean
- `cd site && npm run check:categories` / `check:orphans` / `check:seo` — all pass; the two `missing relatedSkills` orphan warnings (`typo3-site-conformance`, `jujutsu-workflow`) are pre-existing and reproduce identically on the unmodified tree (no local README-fetch cache), unrelated to this change
- `cd site && npm run build:once` — builds cleanly, 91 files; confirmed the facet renders correctly per-skill (label + localized text) on both card and detail pages in EN and DE, and stays absent for plugins without `value_type`
- `node --check` on all new/changed `.js` data files — clean

## Known follow-up

This repo has a Playwright visual-regression snapshot test (`site/tests/visual`). Adding a visible facet to skill cards and detail-page headers changes the rendered output, so the landing/detail snapshots will diff. Per the task brief, snapshots were **not** regenerated locally (proven environment-mismatch). `visual-regression` is a non-required check, so it won't block merge — same known follow-up as #79.

Closes #78
