### PR TITLE
chore(marketplace): remove the retired coach plugin entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -220,15 +220,6 @@
       "value_type": "automation-script"
     },
     {
-      "name": "coach",
-      "description": "Self-improving learning system that detects friction signals (corrections, tool failures, repetition) and proposes rule updates. Includes /coach slash commands for reviewing, approving, and managing learning candidates. Auto-configures hooks for signal detection.",
-      "source": {
-        "source": "github",
-        "repo": "netresearch/claude-coach-plugin"
-      },
-      "category": "productivity"
-    },
-    {
       "name": "concourse-ci",
       "description": "Expert guidance for Concourse CI pipeline development, optimization, and troubleshooting. Pipeline creation, git/registry-image resources, job lifecycle hooks, YAML anchors, multi-branch pipelines with set_pipeline, oci-build-task, and gotchas like tag detection after force-push. Concourse v8.0+.",
       "source": {


### PR DESCRIPTION
Coach is retired in favor of [`retro-skill`](https://github.com/netresearch/retro-skill) — its recorded-friction hook heuristics are superseded by retro's direct LLM session analysis. Removes the `coach` catalog entry (41 → 40 plugins); `validate.sh` passes.

Companion PRs: coach README deprecation (claude-coach-plugin#34), retro coach-events decoupling (retro-skill, in progress). The repo archive follows.

Note: removing a card shifts the landing page, so `visual-regression` (non-required) will fail until the snapshot is refreshed — I'll dispatch `refresh-visual-snapshots.yml` after merge (the workflow added in #82).