### PR TITLE
fix(deps): refresh site lockfile for open advisories

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1835,9 +1835,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2158,10 +2158,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2227,9 +2237,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.2.tgz",
+      "integrity": "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes the five open [Dependabot alerts](https://github.com/netresearch/claude-code-marketplace/security/dependabot) on `site/package-lock.json`, all dev-scope transitives:

| Package | From | To | Advisory |
| --- | --- | --- | --- |
| `js-yaml` | 3.14.2 | 3.15.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m), [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) |
| `js-yaml` | 4.1.1 | 4.3.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m), [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) |
| `brace-expansion` | 1.1.14 | 1.1.16 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) |
| `liquidjs` | 10.27.0 | 10.27.2 | [GHSA-g357-x5c3-c72p](https://github.com/advisories/GHSA-g357-x5c3-c72p) |

`liquidjs` has no alert on this repo — it is alerted on the private mirror and comes along in the same `npm audit fix`.

Produced by `npm audit fix --package-lock-only` in `site/`; no manifest change.

## Verification

`npm ci` + `npm run build:once` — 89 files written, eleventy v3.1.5.

## Not fixed here

`npm audit` still reports `brace-expansion <=5.0.7` (unbounded-expansion OOM). The tree reaches it through `@11ty/eleventy` → `@11ty/recursive-copy@4.0.4` → `minimatch@3.1.5`, which requires `brace-expansion ^1.1.7` and therefore cannot take the fixed 5.0.8. It needs an upstream 11ty release; there is no open Dependabot alert for it on this repo yet.
