### PR TITLE
ci: Renovate-only with signed commits + enforced DCO

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,18 @@
+name: DCO
+
+# Enforced sign-off gate via the shared reusable (dependency bots exempt;
+# reports on merge_group). Humans must sign off (git commit -s).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  dco:
+    uses: netresearch/.github/.github/workflows/dco.yml@main # NOSONAR — own-org reusable deliberately tracks main
+    permissions:
+      contents: read
+      pull-requests: read

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>netresearch/renovate-config"
+  ]
+}


### PR DESCRIPTION
Standardises on the shared `netresearch/renovate-config` (`platformCommit` -> Renovate commits are GitHub-signed), removes Dependabot where present (can't reliably sign; `required_signatures` has no bot exemption), and adds the bot-exempting DCO reusable as the enforced sign-off gate. Prepares `main` for required signed commits + required DCO.