### PR TITLE
docs(readme): note Agent Plugins 1.0.0 packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 **Agentic Skills** are portable packages of procedural knowledge that work across any AI coding agent supporting the [Agent Skills specification](https://agentskills.io).
 
+Every listed repository is also an [Agent Plugins 1.0.0](https://agent-plugins.org) package: a `plugin.json` at the repository root plus the `skills/` directory, which conformant clients load directly from the source repository. This marketplace stays the Claude Code install path — Agent Plugins standardizes packaging, not distribution.
+
 **Supported Platforms:**
 - Claude Code (Anthropic)
 - Cursor


### PR DESCRIPTION
One sentence in *What are Agentic Skills?*: the listed repositories are also [Agent Plugins 1.0.0](https://agent-plugins.org) packages, and this marketplace remains the Claude Code install path — the standard covers packaging, not distribution. No catalog, schema or validator change.

**Draft on purpose.** The sentence is only true once the fleet sweep has merged the root `plugin.json` into the listed repositories (tracked from [netresearch/skill-repo-skill#202](https://github.com/netresearch/skill-repo-skill/pull/202)). Mark ready once that is done.