### PR TITLE
fix(site): bump js-yaml to 4.3.1 and 3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1835,9 +1835,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2158,9 +2158,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Fixes two open Dependabot alerts for js-yaml ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), high severity) in `site/package-lock.json`: [alert #23](https://github.com/netresearch/claude-code-marketplace/security/dependabot/23) (js-yaml >= 4.0.0, < 4.3.1) and [alert #22](https://github.com/netresearch/claude-code-marketplace/security/dependabot/22) (js-yaml >= 3.0.0, < 3.15.1). Dependabot opened no fix PR for these (both instances are transitive devDependencies), so this bumps them manually.

Both patched versions satisfy the consumers' existing semver ranges, so the change is lockfile-only (`npm update js-yaml`) — no package.json change, no overrides: js-yaml 4.3.0 → 4.3.1 (consumer `@11ty/eleventy`, range `^4.1.1`) and js-yaml 3.15.0 → 3.15.1 (consumer `gray-matter`, range `^3.13.1`).

Verification: `npm ls js-yaml --all` shows only 4.3.1 and 3.15.1; `npm run build` (87 pages written), `npm run check` and `npm run check:hreflang` (81 pages, 0 gaps) all pass locally on Node 26 / npm lockfileVersion 3.
