### PR TITLE
fix(ci): bound the refresh job so a hang cannot hold a runner for six hours

### DIFF
--- a/.github/workflows/refresh-visual-snapshots.yml
+++ b/.github/workflows/refresh-visual-snapshots.yml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    # A full pass (install, browsers, fetch, build, snapshots) takes ~4 minutes.
+    # Without a bound, a hung step holds the runner until the 6-hour ceiling.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: site
@@ -34,7 +37,11 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # Same invocation as netresearch/.github's playwright-visual reusable,
+        # which runs this install on every push without hanging. This step still
+        # hangs here for reasons nobody has pinned down (#99) — matching the
+        # reusable removes one variable, it does not fix that.
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: Restore README cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
Refs #99. This PR no longer claims to fix the hang — the diagnosis it started from was disproved by its own verification run, and the issue stays open.

## What is proven

`timeout-minutes: 20` on `jobs.refresh`. The job had no bound at all, so each hang held a runner until the six-hour ceiling and had to be cancelled by hand. Run [32269308335](https://github.com/netresearch/claude-code-marketplace/actions/runs/32269308335) carried this change, hung on the install step as before, and was terminated by the timeout: job start `15:19:32Z`, job end `15:39:51Z`, install step cancelled at `15:39:49Z`. That is the whole value of this PR and it stands on its own.

## What was disproved

The first version of this PR argued that `npx playwright install` blocks on package resolution in a non-TTY job, and switched to `./node_modules/.bin/playwright`. Run 32269308335 carried that change and hung anyway, for twenty minutes, against a 73–80 second baseline. `npx` is not the cause.

Tally so far: `npx` — two hangs, one 73-second success. Local binary in this job — one hang. The same local-binary invocation inside `netresearch/.github`'s `playwright-visual.yml`, which `pages.yml` calls on every push — consistently fast. So the difference is not the invocation.

The install-step change is kept, but only as alignment with the reusable that works and as one variable removed. It is not a fix and the commit message says so.

## What is left

The remaining structural difference between this job and the reusable that never hangs is that the reusable runs `step-security/harden-runner` first and this job runs no hardening step at all. That is a hypothesis, not a finding, and deliberately not shipped here: adding a speculative change to a PR whose main claim just collapsed would repeat the mistake rather than fix it. Recorded on #99 for whoever picks the cause up.

Until then the practical route for refreshing baselines is the one now documented in `site/AGENTS.md` (#100): take the *actual* screenshots out of the `playwright-report` artefact of the failing `pages.yml` run on your own head.