### PR TITLE
fix(ci): bound apt so a stalled mirror cannot hang the snapshot refresh

### DIFF
--- a/.github/workflows/refresh-visual-snapshots.yml
+++ b/.github/workflows/refresh-visual-snapshots.yml
@@ -36,12 +36,35 @@ jobs:
       - name: Install
         run: npm ci
 
+      # apt has no default timeout on package acquisition, so a mirror that
+      # accepts the connection and then stops responding blocks forever instead
+      # of failing. That is what hung this job (#99): `--with-deps` shells out
+      # to `apt-get update`, which stalled on its first mirror fetch for twenty
+      # minutes. Playwright owns that apt invocation, so the bound goes into
+      # apt's own config where the child process picks it up.
+      - name: Bound apt acquisition
+        working-directory: ${{ github.workspace }}
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          Acquire::ftp::Timeout "30";
+          CONF
+
       - name: Install Playwright browsers
-        # Same invocation as netresearch/.github's playwright-visual reusable,
-        # which runs this install on every push without hanging. This step still
-        # hangs here for reasons nobody has pinned down (#99) — matching the
-        # reusable removes one variable, it does not fix that.
-        run: ./node_modules/.bin/playwright install --with-deps chromium
+        # Belt and braces: if a stall survives the apt bound, `timeout` ends the
+        # attempt rather than the job. Output is deliberately not discarded —
+        # a silent stall is what made this take three runs to diagnose.
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 ./node_modules/.bin/playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::playwright install attempt ${attempt} did not complete within 300s"
+          done
+          echo "::error::playwright install did not complete in three attempts"
+          exit 1
 
       - name: Restore README cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
Closes #99, this time with the cause rather than a bound on the symptom.

## The cause

`apt-get`. Log of the hung run [32269308335](https://github.com/netresearch/claude-code-marketplace/actions/runs/32269308335), last two lines before twenty minutes of silence:

```
Installing dependencies...
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
```

`playwright install --with-deps` shells out to `apt-get update` for the browser system libraries, and it stalled on the first mirror fetch. The identical signature stalled a completely unrelated step in another repository the same afternoon — `sudo apt-get update -qq … && sudo apt-get install -y -qq shellcheck` in the shared `validate` workflow, 37 minutes, different repo, different tool.

apt applies no timeout to package acquisition by default, so a mirror that accepts the connection and then stops responding blocks forever instead of failing. That is also the only hypothesis that explains the intermittency: the same command finished in 73 seconds on one run and never on the next, which is mirror state rather than invocation shape.

Three earlier hypotheses are retired by this: `npx` resolution, Playwright flakiness, and the missing `harden-runner` step. None of them touch apt, and the second hang happened in a job that *has* `harden-runner`.

## The fix

`/etc/apt/apt.conf.d/99-ci-timeouts` sets `Acquire::Retries` and per-scheme timeouts. Playwright owns the `apt-get` invocation, so bounding apt through its own configuration is what reaches the child process — passing flags is not an option here.

A `timeout 300` plus three attempts wraps the step for whatever survives that, and the step no longer discards its output. Worst case is 15 minutes, inside the job's 20-minute bound from #101. A retry emits `::warning::` so the flake stays visible instead of being silently absorbed.

## What this does not claim

An intermittent fault cannot be proven gone by one green run. What is verifiable here is that the failure mode is now bounded at every level — apt fails instead of hanging, the step ends instead of the job, the job ends instead of the runner — and that the diagnosis rests on log evidence from two independent hangs rather than on elimination.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
