### PR TITLE
Add offload to the Agent Skills marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,7 +375,7 @@
     },
     {
       "name": "offload",
-      "description": "Delegate parallel coding, research, and review work to headless agy workers with verified outputs.",
+      "description": "Delegate bounded implementation and research work with orchestrator review.",
       "source": {
         "source": "github",
         "repo": "anthonyandrei/offload"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -372,6 +372,15 @@
       },
       "category": "productivity",
       "value_type": "failure-patterns"
+    },
+    {
+      "name": "offload",
+      "description": "Delegate parallel coding, research, and review work to headless agy workers with verified outputs.",
+      "source": {
+        "source": "github",
+        "repo": "anthonyandrei/offload"
+      },
+      "category": "workflow"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,7 +375,7 @@
     },
     {
       "name": "offload",
-      "description": "Delegate bounded implementation and research work with orchestrator review.",
+      "description": "Bounded implementation and research with pre-delegation offers and orchestrator review.",
       "source": {
         "source": "github",
         "repo": "anthonyandrei/offload"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > **You ship code. Your agent should know your stack.**
 
-39 curated Agent Skills for TYPO3, PHP, Go, Docker, Jira, security, and documentation — portable across Claude Code, Cursor, Copilot, Codex, Gemini CLI, and 30+ other agents.
+41 curated Agent Skills for TYPO3, PHP, Go, Docker, Jira, security, and documentation — portable across Claude Code, Cursor, Copilot, Codex, Gemini CLI, and 30+ other agents.
 
 [![Marketplace site](https://img.shields.io/badge/marketplace-netresearch.github.io-2F99A4)](https://netresearch.github.io/claude-code-marketplace/)
-[![Skills](https://img.shields.io/badge/skills-39-2F99A4)](https://netresearch.github.io/claude-code-marketplace/en/skills/)
+[![Skills](https://img.shields.io/badge/skills-41-2F99A4)](https://netresearch.github.io/claude-code-marketplace/en/skills/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/netresearch/claude-code-marketplace/badge)](https://scorecard.dev/viewer/?uri=github.com/netresearch/claude-code-marketplace)
 
@@ -116,7 +116,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | context7 | [context7-skill](https://github.com/netresearch/context7-skill) | Library documentation lookup via Context7 REST API |
 | data-tools | [data-tools-skill](https://github.com/netresearch/data-tools-skill) | Structured data manipulation with jq, yq, dasel, qsv |
 | file-search | [file-search-skill](https://github.com/netresearch/file-search-skill) | Efficient code search with ripgrep, ast-grep, fd |
-| offload | [offload](https://github.com/anthonyandrei/offload) | Delegate parallel coding, research, and review work to headless agy workers with verified outputs |
+| offload | [offload](https://github.com/anthonyandrei/offload) | Delegate bounded implementation and research work with orchestrator review |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | context7 | [context7-skill](https://github.com/netresearch/context7-skill) | Library documentation lookup via Context7 REST API |
 | data-tools | [data-tools-skill](https://github.com/netresearch/data-tools-skill) | Structured data manipulation with jq, yq, dasel, qsv |
 | file-search | [file-search-skill](https://github.com/netresearch/file-search-skill) | Efficient code search with ripgrep, ast-grep, fd |
+| offload | [offload](https://github.com/anthonyandrei/offload) | Delegate parallel coding, research, and review work to headless agy workers with verified outputs |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | context7 | [context7-skill](https://github.com/netresearch/context7-skill) | Library documentation lookup via Context7 REST API |
 | data-tools | [data-tools-skill](https://github.com/netresearch/data-tools-skill) | Structured data manipulation with jq, yq, dasel, qsv |
 | file-search | [file-search-skill](https://github.com/netresearch/file-search-skill) | Efficient code search with ripgrep, ast-grep, fd |
-| offload | [offload](https://github.com/anthonyandrei/offload) | Delegate bounded implementation and research work with orchestrator review |
+| offload | [offload](https://github.com/anthonyandrei/offload) | Bounded implementation and research with pre-delegation offers and orchestrator review. |
 | coach | [claude-coach-plugin](https://github.com/netresearch/claude-coach-plugin) | Self-improving learning system with hooks and commands |
 | german-technical-writing | [german-technical-writing-skill](https://github.com/netresearch/german-technical-writing-skill) | Natural German technical register for Jira, internal docs, team chat — catches anglicisms, enforces lexicon |
 | peer-qa-review | [peer-qa-review-skill](https://github.com/netresearch/peer-qa-review-skill) | Round-1 IT QA peer-review runbook: lifecycle, severity vocabulary, structured Jira comment template, edge cases, anti-patterns |


### PR DESCRIPTION
## Summary

- Add `anthonyandrei/offload` to `.claude-plugin/marketplace.json`.
- Add the corresponding README catalog row.
- Categorize it as a workflow skill for bounded implementation and research work with pre-delegation offers and orchestrator review.

The source repository is public and MIT-licensed. Offload is provider-agnostic and discovers current worker tools at runtime, with model and effort choices kept runtime-dynamic.

## Validation

- `.claude-plugin/marketplace.json` parses as valid JSON.
- Marketplace structure, duplicate/category/slug/description checks pass.
- The README count and catalog row match the 41 marketplace records.

## Source contract

The catalog entry matches the source skill's current contract. Offload offers once before native multi-agent delegation for two or more independent, bounded assignments, requires consent before dispatch, and lets native delegation continue after a decline.