### PR TITLE
fix(site): repair PHP skill discovery and engine onboarding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -137,7 +137,7 @@
     },
     {
       "name": "php-structured-edit",
-      "description": "Edits PHP through its AST rather than regex, sed or patch, so a rename hits the identifier and not the same-named string literal beside it. Ten typed operations on nikic/php-parser, guarded by SHA-256 and expected node type, reparsed before write. Ships the php-ast-edit CLI.",
+      "description": "Edit PHP methods, parameters and expressions with named selectors, typed operations and SHA-256 guards. Supports multi-file batches, format-preserving output and optional canonical printing. Review diffs and run lint/project tests; syntax checks do not prove behavior.",
       "source": {
         "source": "github",
         "repo": "netresearch/php-ast-edit-skill"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Record intentional deviations from a source skill repo. Empty by default.
 
 | Slug | Field | Marketplace value | Reason | Decided |
 |---|---|---|---|---|
+| php-structured-edit | Installation commands and hints | `site/src/_data/installOverrides.json` | The PHP engine needs a VCS install until Packagist publication; skill registration alone does not install its runtime. Commands follow the source installation guide. | 2026-09-06 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Host-side tooling (not Agent Skills themselves, but part of the same family):
 | Skill | Repository | Description |
 |-------|-----------|-------------|
 | php-modernization | [php-modernization-skill](https://github.com/netresearch/php-modernization-skill) | PHP 8.x modernization: type safety, enums, DTOs, PHPStan, Rector |
-| php-structured-edit | [php-ast-edit-skill](https://github.com/netresearch/php-ast-edit-skill) | AST-native PHP edits via nikic/php-parser — typed mutations, hash guards, reparse before write |
+| php-structured-edit | [php-ast-edit-skill](https://github.com/netresearch/php-ast-edit-skill) | Select PHP symbols, apply typed edits in guarded batches, and review the diff; project tests remain necessary |
 | security-audit | [security-audit-skill](https://github.com/netresearch/security-audit-skill) | OWASP security audit patterns for PHP applications |
 | enterprise-readiness | [enterprise-readiness-skill](https://github.com/netresearch/enterprise-readiness-skill) | Supply chain security, SLSA, OpenSSF, SBOMs, quality gates |
 

--- a/site/README.md
+++ b/site/README.md
@@ -13,6 +13,8 @@ overrides). Design rationale lives in [`../docs/decisions/`](../docs/decisions/)
 
 ## Quick start
 
+Requires Node.js 20.10.0 or newer for JSON import attributes.
+
 ```bash
 cd site
 npm install

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -17,7 +17,7 @@
         "http-server": "^14.1.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.10.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/site/package.json
+++ b/site/package.json
@@ -29,7 +29,7 @@
     "http-server": "^14.1.1"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.10.0"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",

--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,7 @@
     "check:categories": "node scripts/check-categories.js",
     "check:seo": "node scripts/check-seo-copy.js",
     "check:hreflang": "node scripts/check-hreflang.js",
-    "check": "npm run check:categories && npm run check:orphans && npm run check:seo",
+    "check": "npm run check:categories && npm run check:orphans && npm run check:seo && npm run check:install",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "prebuild": "npm run check:categories && npm run og:generate",
@@ -20,7 +20,8 @@
     "build:all": "npm run fetch:readmes && npm run check && npm run build:once && npm run check:hreflang",
     "dev": "eleventy --serve --port=8080",
     "preview": "npx http-server _site -p 8080 -c-1",
-    "clean": "rm -rf _site"
+    "clean": "rm -rf _site",
+    "check:install": "node --test tests/install-methods.test.js"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/site/scripts/parse-readme.js
+++ b/site/scripts/parse-readme.js
@@ -192,8 +192,11 @@ export function parseReadme(markdown) {
   const useCasesBlock = findSection(markdown, SECTION_ALIASES.useCases);
   const expectedOutputsBlock = findSection(markdown, SECTION_ALIASES.expectedOutputs);
   // Dedicated context guidance takes priority when onboarding appears first.
+  // Exclude it from fallback matching so an empty section cannot hide onboarding.
   const contextBlock = findSection(markdown, ["context requirements"])
-    ?? findSection(markdown, SECTION_ALIASES.contextRequirements);
+    ?? findSection(markdown, SECTION_ALIASES.contextRequirements.filter(
+      (alias) => alias !== "context requirements",
+    ));
   const relatedBlock = findSection(markdown, SECTION_ALIASES.relatedSkills);
   const tagsBlock = findSection(markdown, SECTION_ALIASES.tags);
 

--- a/site/scripts/parse-readme.js
+++ b/site/scripts/parse-readme.js
@@ -191,7 +191,9 @@ export function parseReadme(markdown) {
 
   const useCasesBlock = findSection(markdown, SECTION_ALIASES.useCases);
   const expectedOutputsBlock = findSection(markdown, SECTION_ALIASES.expectedOutputs);
-  const contextBlock = findSection(markdown, SECTION_ALIASES.contextRequirements);
+  // Dedicated context guidance takes priority when onboarding appears first.
+  const contextBlock = findSection(markdown, ["context requirements"])
+    ?? findSection(markdown, SECTION_ALIASES.contextRequirements);
   const relatedBlock = findSection(markdown, SECTION_ALIASES.relatedSkills);
   const tagsBlock = findSection(markdown, SECTION_ALIASES.tags);
 

--- a/site/src/_data/descriptions_de.json
+++ b/site/src/_data/descriptions_de.json
@@ -14,7 +14,7 @@
   "typo3-upgrade-effort-model": "Aufwands-Modell für TYPO3-LTS-Upgrades: Risiko-Multiplikatoren, Baselines, Version-Compat, Rector-Coverage, 7-Phasen-Workflow.",
   "orocommerce": "OroCommerce-Entwicklung: Entities, Datagrids, REST-API, Workflows, Frontend, Security, Integration, Bundle-Scaffolding.",
   "php-modernization": "PHP-8.x-Modernisierung: Type-Safety, Enums, DTOs, PHPStan, Rector.",
-  "php-structured-edit": "PHP-Änderungen über den AST statt über Regex oder sed: typisierte Operationen auf nikic/php-parser, Hash-Guards, erneutes Parsen vor dem Schreiben.",
+  "php-structured-edit": "PHP-Methoden, Parameter und Ausdrücke gezielt ändern: AST-Selektoren, typisierte Operationen und Hash-Prüfungen; mehrere Dateien pro Auftrag. Ohne Normalisierung starten; kanonische Formatierung ist optional. Syntaxprüfung ersetzt keine Verhaltenstests.",
   "security-audit": "OWASP-Security-Audit-Patterns für PHP-Anwendungen.",
   "enterprise-readiness": "Supply-Chain-Security, SLSA, OpenSSF, SBOMs, Quality-Gates.",
   "automated-assessment": "Systematische Projekt-Bewertung mit Skript- und LLM-gestützter Verifikation.",

--- a/site/src/_data/installOverrides.json
+++ b/site/src/_data/installOverrides.json
@@ -1,0 +1,76 @@
+{
+  "_doc": "Per-skill installation exceptions owned by the marketplace. Commands follow the linked source guide; default methods for every other skill remain unchanged.",
+  "php-structured-edit": {
+    "linkLabel": {
+      "en": "Engine and skill setup",
+      "de": "Engine und Skill einrichten"
+    },
+    "methods": {
+      "claude-code": {
+        "hint": {
+          "en": {
+            "text": "Installs the agent instructions. The PHP editing engine is set up separately:",
+            "linkText": "engine installation guide",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "Requires PHP 8.2+, ext-json and ext-tokenizer."
+          },
+          "de": {
+            "text": "Installiert die Agent-Anweisungen. Die PHP-Engine wird getrennt eingerichtet:",
+            "linkText": "Engine installieren",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "Benötigt PHP 8.2+, ext-json und ext-tokenizer."
+          }
+        }
+      },
+      "npx": {
+        "hint": {
+          "en": {
+            "text": "Installs the agent instructions. The PHP editing engine is set up separately:",
+            "linkText": "engine installation guide",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "Requires PHP 8.2+, ext-json and ext-tokenizer."
+          },
+          "de": {
+            "text": "Installiert die Agent-Anweisungen. Die PHP-Engine wird getrennt eingerichtet:",
+            "linkText": "Engine installieren",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "Benötigt PHP 8.2+, ext-json und ext-tokenizer."
+          }
+        }
+      },
+      "composer-require": {
+        "command": "composer config repositories.php-ast-edit vcs https://github.com/netresearch/php-ast-edit-skill.git && composer require --dev --no-plugins --no-scripts netresearch/php-ast-edit-skill:dev-main",
+        "hint": {
+          "en": {
+            "text": "Installs the PHP engine from the development branch with Composer plugins and scripts disabled. For release status and separate skill registration, see",
+            "linkText": "source installation guide",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "No Packagist publication or plugin activation is required for this engine path."
+          },
+          "de": {
+            "text": "Installiert die PHP-Engine aus dem Entwicklungszweig; Composer-Plugins und -Skripte bleiben deaktiviert. Releasestand und separate Skill-Registrierung:",
+            "linkText": "Installationsanleitung",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "Dieser Weg benötigt weder eine Packagist-Veröffentlichung noch ein aktiviertes Composer-Plugin."
+          }
+        }
+      },
+      "composer-skills": {
+        "hint": {
+          "en": {
+            "text": "Requires the Composer skill installer and registers the agent instructions. Set up the PHP engine separately:",
+            "linkText": "engine installation guide",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "The skills:add command does not install the engine dependencies."
+          },
+          "de": {
+            "text": "Benötigt den Composer-Skill-Installer und registriert die Agent-Anweisungen. Die PHP-Engine wird getrennt eingerichtet:",
+            "linkText": "Engine installieren",
+            "linkUrl": "https://github.com/netresearch/php-ast-edit-skill#installation",
+            "suffix": "skills:add installiert die Abhängigkeiten der Engine nicht."
+          }
+        }
+      }
+    }
+  }
+}

--- a/site/src/_data/installOverrides.json
+++ b/site/src/_data/installOverrides.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Per-skill installation exceptions owned by the marketplace. Commands follow the linked source guide; default methods for every other skill remain unchanged.",
+  "_doc": "Per-skill installation exceptions owned by the marketplace. The PHP override follows the source guide updated in https://github.com/netresearch/php-ast-edit-skill/pull/29; publish this override after that source change merges. Default methods for every other skill remain unchanged.",
   "php-structured-edit": {
     "linkLabel": {
       "en": "Engine and skill setup",

--- a/site/src/_data/skills.js
+++ b/site/src/_data/skills.js
@@ -24,6 +24,7 @@ import groups from "./groups.js";
 import descriptionsDe from "./descriptions_de.json" with { type: "json" };
 import { displayName } from "./_helpers/display-name.js";
 import installMethods from "./installMethods.js";
+import installOverrides from "./installOverrides.json" with { type: "json" };
 
 function loadCache(slug) {
   const p = resolve(CACHE_DIR, `${slug}.json`);
@@ -74,8 +75,15 @@ export default function () {
       slug: plugin.name,
       repo: plugin.source?.repo,
     };
+    const installOverride = installOverrides[plugin.name] || {};
     const installCommands = Object.fromEntries(
-      installMethods.methods.map((m) => [m.id, m.command(skillStub, marketplace)])
+      installMethods.methods.map((m) => [
+        m.id,
+        installOverride.methods?.[m.id]?.command ?? m.command(skillStub, marketplace),
+      ])
+    );
+    const installHints = Object.fromEntries(
+      installMethods.methods.map((m) => [m.id, installOverride.methods?.[m.id]?.hint ?? m.hint])
     );
 
     return {
@@ -103,6 +111,8 @@ export default function () {
       installCommand: installCommands["claude-code"],
       npxCommand: installCommands["npx"],
       installCommands,
+      installHints,
+      installLinkLabel: installOverride.linkLabel || null,
       canonicalUrlEn: `/en/skills/${plugin.name}/`,
       canonicalUrlDe: `/de/skills/${plugin.name}/`,
       useCases: parsed?.useCases?.length ? parsed.useCases : [],

--- a/site/src/_includes/layouts/skill.njk
+++ b/site/src/_includes/layouts/skill.njk
@@ -41,7 +41,7 @@ layout: layouts/base.njk
       {% for method in installMethods.methods %}
         {% if skill.installCommands[method.id] %}
           {% set labels = method.labels.de if lang == 'de' else method.labels.en %}
-          {% set hint = (method.hint.de if lang == 'de' else method.hint.en) if method.hint else null %}
+          {% set hint = (skill.installHints[method.id].de if lang == 'de' else skill.installHints[method.id].en) if skill.installHints[method.id] else null %}
           <li class="install-methods__item">
             <header class="install-methods__header">
               <span class="install-methods__label">{{ labels.tab }}</span>

--- a/site/src/_includes/partials/skill-card.njk
+++ b/site/src/_includes/partials/skill-card.njk
@@ -19,6 +19,6 @@
               data-copied-label="{{ t.ui.copyCopied }}"
               aria-label="{{ t.skill.copyInstall }} {{ skill.slug }}">{{ t.ui.copyShort }}</button>
     </div>
-    <a class="skill-card__more-install" href="{{ ('/' ~ lang ~ '/skills/' ~ skill.slug ~ '/#install') | url }}">{{ t.ui.moreInstallMethods }} →</a>
+    <a class="skill-card__more-install" href="{{ ('/' ~ lang ~ '/skills/' ~ skill.slug ~ '/#install') | url }}">{{ skill.installLinkLabel[lang] if skill.installLinkLabel else t.ui.moreInstallMethods }} →</a>
   </footer>
 </article>

--- a/site/tests/install-methods.test.js
+++ b/site/tests/install-methods.test.js
@@ -70,3 +70,8 @@ test("an empty explicit context section retains installation fallback", () => {
   const parsed = parseReadme("## Installation\n\nPHP 8.2 and Composer.\n\n## Context requirements\n\n## Outputs\n\nA diff.\n");
   assert.deepEqual(parsed.contextRequirements, ["PHP 8.2 and Composer."]);
 });
+
+test("an empty explicit context section does not hide a later installation fallback", () => {
+  const parsed = parseReadme("## Context requirements\n\n## Installation\n\nPHP 8.2 and Composer.\n\n## Outputs\n\nA diff.\n");
+  assert.deepEqual(parsed.contextRequirements, ["PHP 8.2 and Composer."]);
+});

--- a/site/tests/install-methods.test.js
+++ b/site/tests/install-methods.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 import { readFileSync } from "node:fs";
 import loadSkills from "../src/_data/skills.js";
 import methods from "../src/_data/installMethods.js";
+import { parseReadme } from "../scripts/parse-readme.js";
 
 const marketplace = JSON.parse(readFileSync(new URL("../../.claude-plugin/marketplace.json", import.meta.url)));
 const skills = loadSkills();
@@ -34,4 +35,38 @@ test("other skills retain every default install command and hint", () => {
     }
     assert.equal(skill.installLinkLabel, null, skill.slug);
   }
+});
+
+test("explicit context requirements take priority over earlier installation notices", () => {
+  const parsed = parseReadme(`# PHP editing tool
+
+## Installation
+
+When reviewing this change before it merges, run commands from the reviewed checkout.
+Published archives remain unchanged until a subsequent release.
+
+## Context requirements
+
+Provide the target file paths, intended change, and a writable working tree.
+
+## Expected outputs
+
+- A guarded edit and a measured diff.
+`);
+  assert.deepEqual(parsed.contextRequirements, [
+    "Provide the target file paths, intended change, and a writable working tree.",
+  ]);
+  assert.deepEqual(parsed.expectedOutputs, ["A guarded edit and a measured diff."]);
+});
+
+test("context extraction retains existing fallback aliases and document order", () => {
+  for (const heading of ["Installation", "Requirements", "Setup", "Dependencies"]) {
+    const parsed = parseReadme(`## ${heading}\n\n- PHP 8.2 and Composer.\n\n## Context\n\n- A later fallback.\n`);
+    assert.deepEqual(parsed.contextRequirements, ["PHP 8.2 and Composer."], heading);
+  }
+});
+
+test("an empty explicit context section retains installation fallback", () => {
+  const parsed = parseReadme("## Installation\n\nPHP 8.2 and Composer.\n\n## Context requirements\n\n## Outputs\n\nA diff.\n");
+  assert.deepEqual(parsed.contextRequirements, ["PHP 8.2 and Composer."]);
 });

--- a/site/tests/install-methods.test.js
+++ b/site/tests/install-methods.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import loadSkills from "../src/_data/skills.js";
+import methods from "../src/_data/installMethods.js";
+
+const marketplace = JSON.parse(readFileSync(new URL("../../.claude-plugin/marketplace.json", import.meta.url)));
+const skills = loadSkills();
+
+test("the PHP engine has a VCS installation route without plugin activation", () => {
+  const skill = skills.find(({ slug }) => slug === "php-structured-edit");
+  const command = skill.installCommands["composer-require"];
+  assert.match(command, /composer config repositories\.php-ast-edit vcs https:\/\/github\.com\/netresearch\/php-ast-edit-skill/);
+  assert.match(command, /composer require --dev --no-plugins --no-scripts netresearch\/php-ast-edit-skill:dev-main/);
+  // Cards use white-space: nowrap and copy innerText, which collapses newlines.
+  // Keep the two commands connected even after browser whitespace normalization.
+  assert.match(command, /\.git && composer require /);
+  assert.equal(command.includes("\n"), false);
+  for (const language of ["en", "de"]) {
+    assert.ok(skill.installLinkLabel[language]);
+    for (const { id } of methods.methods) {
+      const hint = skill.installHints[id][language];
+      assert.equal(hint.linkUrl, "https://github.com/netresearch/php-ast-edit-skill#installation");
+      assert.ok(hint.text && hint.linkText && hint.suffix);
+    }
+  }
+});
+
+test("other skills retain every default install command and hint", () => {
+  for (const skill of skills.filter(({ slug }) => slug !== "php-structured-edit")) {
+    for (const method of methods.methods) {
+      assert.equal(skill.installCommands[method.id], method.command(skill, marketplace), skill.slug);
+      assert.deepEqual(skill.installHints[method.id], method.hint, skill.slug);
+    }
+    assert.equal(skill.installLinkLabel, null, skill.slug);
+  }
+});

--- a/site/tests/visual/install.spec.js
+++ b/site/tests/visual/install.spec.js
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import overrides from "../../src/_data/installOverrides.json" with { type: "json" };
+
+for (const language of ["en", "de"]) {
+  test(`PHP engine install command survives card copy (${language})`, async ({ page }) => {
+    // Capture this page's own copy request without reading the system clipboard.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: async (text) => { window.installCommandCopied = text; } },
+      });
+    });
+    await page.goto(`/claude-code-marketplace/${language}/`);
+    await page.getByRole("tab", { name: /composer require/ }).click();
+    const card = page.locator(".skill-card").filter({
+      has: page.getByRole("link", { name: "PHP Structured Edit", exact: true }),
+    });
+    await card.locator(".copy-btn").click();
+    const install = overrides["php-structured-edit"];
+    await expect.poll(() => page.evaluate(() => window.installCommandCopied))
+      .toBe(install.methods["composer-require"].command);
+
+    await card.getByRole("link", { name: install.linkLabel[language] }).click();
+    const hint = install.methods["composer-require"].hint[language];
+    await expect(page.locator(".install-methods__hint").filter({ hasText: hint.text })).toBeVisible();
+    await expect(page.locator("#skill-install-composer-require"))
+      .toHaveText(install.methods["composer-require"].command);
+  });
+}


### PR DESCRIPTION
## What changed

The PHP skill listing currently advertises an outdated operation count and a Composer command that depends on an unavailable Packagist package. Update the English/German copy and give this skill a tested VCS installation path, with explicit separation between engine installation and agent-instruction registration.

Installation overrides live in per-skill data. The shared templates consume them without hardcoding the PHP slug. Other skills retain the default commands, hints and labels. The copied VCS command uses `&&` so browser whitespace normalization cannot merge two commands into invalid shell syntax.

The site declares Node >=20.10.0, matching its JSON import syntax. The installation override records its source-guide provenance and merge dependency explicitly.

README extraction now prefers an explicit `Context requirements` section over an earlier generic installation section. This prevents the engine PR's temporary review notice from appearing as agent context while retaining existing fallbacks.

This accompanies [netresearch/php-ast-edit-skill#29](https://github.com/netresearch/php-ast-edit-skill/pull/29). Merge the engine fixes first: the VCS command follows development `main`, and old release artifacts remain unchanged.

## Validation

- Marketplace validator, 40-skill category/orphan/SEO checks, site build and 83-page hreflang checks pass.
- Six generator/parser tests verify the PHP installation route, unchanged defaults, explicit-context priority and empty-section fallbacks in both heading orders. All 40 cached README parse results remain unchanged.
- Seven Playwright checks pass, including English/German copy and navigation assertions.
- Node 20.9.0 reproduces the import syntax failure. A clean engine-strict dependency install, compliance/install checks, build, hreflang and all seven Playwright tests pass on exactly Node 20.10.0.
- Generated detail pages for the other 39 skills remain byte-identical; no visual baselines or generated assets changed.
- The published commit is GitHub-signed and has a DCO sign-off.
